### PR TITLE
Use dtolnay/rust-toolchain instead of actions-rs/toolchain

### DIFF
--- a/.github/workflows/verify-crate.yaml
+++ b/.github/workflows/verify-crate.yaml
@@ -34,11 +34,9 @@ jobs:
         with:
           version: '3.x'
 
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy, rustfmt
-          override: true
 
       - name: cache dependencies
         uses: Swatinem/rust-cache@v2.2.1


### PR DESCRIPTION
`actions-rs/toolchain` はメンテ止まってて使わない方がいいので，乗り換え