### PR TITLE
Add patch.crates-io for local testing

### DIFF
--- a/kble-serialport/.cargo/config.toml
+++ b/kble-serialport/.cargo/config.toml
@@ -1,0 +1,3 @@
+# for local testing
+[patch.crates-io]
+kble-socket = { path = "../kble-socket" }

--- a/kble-tfsync/.cargo/config.toml
+++ b/kble-tfsync/.cargo/config.toml
@@ -1,0 +1,3 @@
+# for local testing
+[patch.crates-io]
+kble-socket = { path = "../kble-socket" }


### PR DESCRIPTION
`kble-serialport` and `kble-tfsync` depend on `kble-socket` crate in the same repository.
When the version of `kble-socket` on which they depend was not published, builds will never succeed.
eg. https://github.com/arkedge/kble/actions/runs/4796029162/jobs/8531314682

This patch solves the above issue.

FYI: @sksat 