### PR TITLE
Use repo token to install protoc on CI

### DIFF
--- a/.github/workflows/verify-crate.yaml
+++ b/.github/workflows/verify-crate.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@v1
         with:


### PR DESCRIPTION
- 連続して CI 回しまくったので API limit exceeded してた（#14）
- ので，repo token を使うようにして緩和する