### PR TITLE
Integrate with notalawyer

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,10 @@ jobs:
       - name: cache dependencies
         uses: Swatinem/rust-cache@v2.7.3
 
+      - name: install cargo-about
+        run: |
+          cargo install cargo-about
+
       - name: reviewdog / clippy
         uses: sksat/action-clippy@v0.5.1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,9 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "notalawyer",
+ "notalawyer-build",
+ "notalawyer-clap",
  "pin-project",
  "serde",
  "serde_with",
@@ -800,6 +803,9 @@ dependencies = [
  "clap",
  "futures",
  "kble-socket",
+ "notalawyer",
+ "notalawyer-build",
+ "notalawyer-clap",
  "tokio",
  "tokio-util",
  "tracing",
@@ -816,6 +822,9 @@ dependencies = [
  "eb90",
  "futures",
  "kble-socket",
+ "notalawyer",
+ "notalawyer-build",
+ "notalawyer-clap",
  "tokio",
  "tokio-util",
  "tracing",
@@ -832,6 +841,9 @@ dependencies = [
  "clap",
  "futures",
  "kble-socket",
+ "notalawyer",
+ "notalawyer-build",
+ "notalawyer-clap",
  "serde",
  "tokio",
  "tokio-serial",
@@ -977,6 +989,28 @@ dependencies = [
  "memoffset",
  "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "notalawyer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6f7d5c326e17c81351d91ed10b175ba5afbfc276ca232d115490e876f7e4e7"
+
+[[package]]
+name = "notalawyer-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6e1b1f2c9f35e548539a8216afdfeb0ee62743e99664e6c5b3b0f815a9fdf7"
+
+[[package]]
+name = "notalawyer-clap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43962175b7e1f02c3fa7458b4970bdd0b78fa81272c2de2ebd1868120e2dac48"
+dependencies = [
+ "clap",
+ "notalawyer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ serde = { version = "1", features = ["derive"]}
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 kble-socket = "0.2.0"
+notalawyer = "0.1.0"
+notalawyer-clap = "0.1.0"
+notalawyer-build = "0.1.0"

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,7 @@
+accepted = [
+    "MIT",
+    "Apache-2.0",
+    "Unicode-DFS-2016",
+    "MPL-2.0",
+    "BSD-2-Clause",
+]

--- a/kble-c2a/Cargo.toml
+++ b/kble-c2a/Cargo.toml
@@ -9,6 +9,9 @@ readme.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+notalawyer-build.workspace = true
+
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true
@@ -19,3 +22,5 @@ bytes.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 clap.workspace = true
+notalawyer.workspace = true
+notalawyer-clap.workspace = true

--- a/kble-c2a/build.rs
+++ b/kble-c2a/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    notalawyer_build::build();
+}

--- a/kble-c2a/src/main.rs
+++ b/kble-c2a/src/main.rs
@@ -3,6 +3,7 @@ use bytes::BytesMut;
 use clap::{Parser, Subcommand};
 use futures::{SinkExt, StreamExt};
 use kble_c2a::{spacepacket, tfsync};
+use notalawyer_clap::*;
 use tokio_util::codec::Decoder;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
@@ -43,7 +44,7 @@ async fn main() -> Result<()> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let args = Args::parse();
+    let args = Args::parse_with_license_notice(include_notice!());
     match args.command {
         Commands::Tfsync => run_tfsync().await,
         Commands::Spacepacket { command } => run_spacepacket(command).await,

--- a/kble-eb90/Cargo.toml
+++ b/kble-eb90/Cargo.toml
@@ -9,6 +9,9 @@ readme.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+notalawyer-build.workspace = true
+
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true
@@ -20,3 +23,5 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 clap.workspace = true
 eb90 = "0.1.1"
+notalawyer.workspace = true
+notalawyer-clap.workspace = true

--- a/kble-eb90/build.rs
+++ b/kble-eb90/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    notalawyer_build::build();
+}

--- a/kble-eb90/src/main.rs
+++ b/kble-eb90/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use bytes::BytesMut;
 use clap::{Parser, Subcommand};
 use futures::{SinkExt, StreamExt};
+use notalawyer_clap::*;
 use tokio_util::codec::{Decoder, Encoder};
 use tracing::warn;
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -35,7 +36,7 @@ async fn main() -> Result<()> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let args = Args::parse();
+    let args = Args::parse_with_license_notice(include_notice!());
     match args.command {
         Commands::Encode => run_encode().await,
         Commands::Decode { buffer_size } => run_decode(buffer_size).await,

--- a/kble-serialport/Cargo.toml
+++ b/kble-serialport/Cargo.toml
@@ -9,6 +9,9 @@ readme.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+notalawyer-build.workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
@@ -21,3 +24,5 @@ axum = { workspace = true, default-features = false, features = ["tokio", "tower
 tokio-serial = "5.4"
 serde.workspace = true
 bytes.workspace = true
+notalawyer.workspace = true
+notalawyer-clap.workspace = true

--- a/kble-serialport/build.rs
+++ b/kble-serialport/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    notalawyer_build::build();
+}

--- a/kble-serialport/src/main.rs
+++ b/kble-serialport/src/main.rs
@@ -12,6 +12,7 @@ use bytes::BytesMut;
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
 use kble_socket::from_axum;
+use notalawyer_clap::*;
 use serde::Deserialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_serial::{DataBits, FlowControl, Parity, SerialPortBuilderExt, SerialStream, StopBits};
@@ -100,7 +101,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let args = Args::parse_with_license_notice(include_notice!());
 
     tracing_subscriber::registry()
         .with(

--- a/kble/Cargo.toml
+++ b/kble/Cargo.toml
@@ -9,6 +9,9 @@ readme.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+notalawyer-build.workspace = true
+
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true
@@ -21,3 +24,5 @@ clap.workspace = true
 serde.workspace = true
 serde_yaml = "0.9"
 serde_with = "3.4"
+notalawyer.workspace = true
+notalawyer-clap.workspace = true

--- a/kble/build.rs
+++ b/kble/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    notalawyer_build::build();
+}

--- a/kble/src/main.rs
+++ b/kble/src/main.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use notalawyer_clap::*;
 
 mod plug;
 mod spaghetti;
@@ -27,7 +28,7 @@ impl Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let args = Args::parse_with_license_notice(include_notice!());
     let config = args.load_spaghetti_config()?;
     config.run().await?;
     Ok(())


### PR DESCRIPTION
To prepare for future binary distribution, use [notalawyer](https://github.com/arkedge/notalawyer) to display the binary crate license.

This requires [cargo-about](https://github.com/EmbarkStudios/cargo-about) to be installed before building.

Affected crates: `kble`, `kble-c2a`, `kble-eb90`, `kble-serialport`