### PR TITLE
Add release automation workflow for binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: install apt depenedencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Get Rust toolchain
+        id: toolchain
+        working-directory: .
+        run: |
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2.7.3
+
+      - name: install cargo-about
+        run: |
+          cargo install --locked cargo-about
+
+      - name: Build
+        run: |
+          cargo build --target=${{ matrix.target }} --release --locked
+
+      - name: Rename binaries
+        run: |
+          mkdir bin
+          kble_bins=("kble" "kble-c2a" "kble-eb90" "kble-serialport")
+          for b in "${kble_bins[@]}" ; do
+            cp "./target/${{ matrix.target }}/release/${b}" "./bin/${b}-${{ matrix.target }}"
+          done
+          ls -lh ./bin
+
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: release-executable-${{ matrix.target }}
+          if-no-files-found: error
+          path: ./bin/
+
+  build_kble_serialport_win:
+    name: build / kble-serialport.exe
+    # C2A Boom ecosystem does **NOT** support native Windows environment.
+    # However, WSL2 environment is supported and has many use cases in the real world.
+    # Here, there are difficulties in running kble-serialport inside WSL2,
+    #  a component that interfaces with external hardware (USB-RS devices).
+    # Although it is possible to show a Windows host USB devices
+    #  to a WSL2 Linux VM using the usbipd-win project, this is still a bit unstable.
+    # Also, kble-serialport is a very small component that does not need to be updated frequently for practical use.
+    # For these reasons, we currently choose to run only kble-serialport on Windows host.
+
+    runs-on: windows-2022
+
+    env:
+      TARGET: x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Get Rust toolchain
+        id: toolchain
+        working-directory: .
+        run: |
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+          targets: ${{ env.TARGET }}
+
+      - uses: Swatinem/rust-cache@v2.7.3
+
+      - name: install cargo-about
+        run: |
+          cargo install --locked cargo-about
+
+      - name: Build
+        run: |
+          cargo build --target=${{ env.TARGET }} -p kble-serialport --release --locked
+
+      - name: Rename binary
+        run: |
+          mkdir bin
+          cp "./target/${{ env.TARGET }}/release/kble-serialport" "./bin/kble-serialport-${{ env.TARGET }}"
+          ls -lh ./bin
+
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: release-executable-${{ env.TARGET }}
+          if-no-files-found: error
+          path: ./bin/
+
+  release:
+    name: Release
+    needs: [ build, build_kble_serialport_win ]
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/download-artifact@v4.1.3
+        with:
+          pattern: release-executable-*
+          merge-multiple: true
+
+      - run: ls -lh
+
+      - name: Release to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          files: |
+            kble*


### PR DESCRIPTION
- Binary-integrated license notice display is implemented in #59 
- Supported platform
  - Linux (x86_64): Build with musl libc
  - Windows (only `kble-serialport`): Build with MSVC (ABI/Linker)
    - reason: see `build_kble_serialport_win` job comment