### PR TITLE
簡単なリファクタ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,8 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/kble/Cargo.toml
+++ b/kble/Cargo.toml
@@ -24,5 +24,7 @@ clap.workspace = true
 serde.workspace = true
 serde_yaml = "0.9"
 serde_with = "3.7"
+tracing-subscriber.workspace = true
+tracing.workspace = true
 notalawyer.workspace = true
 notalawyer-clap.workspace = true

--- a/kble/src/app.rs
+++ b/kble/src/app.rs
@@ -7,18 +7,18 @@ use std::collections::HashMap;
 pub async fn run(config: &Config) -> Result<()> {
     let mut sinks = HashMap::new();
     let mut streams = HashMap::new();
-    for (name, url) in config.plugs.iter() {
+    for (name, url) in config.plugs().iter() {
         let (sink, stream) = plug::connect(url).await?;
         sinks.insert(name.as_str(), sink);
         streams.insert(name.as_str(), stream);
     }
     let mut edges = vec![];
-    for (stream_name, sink_name) in config.links.iter() {
+    for (stream_name, sink_name) in config.links().iter() {
         let Some(stream) = streams.remove(stream_name.as_str()) else {
-            return Err(anyhow!("No such plug: {stream_name}"));
+            unreachable!("No such plug: {stream_name}");
         };
         let Some(sink) = sinks.remove(sink_name.as_str()) else {
-            return Err(anyhow!("No such plug or already used: {sink_name}"));
+            unreachable!("No such plug or already used: {sink_name}");
         };
         let edge = stream.forward(sink);
         edges.push(edge);

--- a/kble/src/app.rs
+++ b/kble/src/app.rs
@@ -1,5 +1,5 @@
 use crate::{plug, spaghetti::Config};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use futures::future;
 use futures::StreamExt;
 use std::collections::HashMap;

--- a/kble/src/app.rs
+++ b/kble/src/app.rs
@@ -1,0 +1,28 @@
+use crate::{plug, spaghetti::Config};
+use anyhow::{anyhow, Result};
+use futures::future;
+use futures::StreamExt;
+use std::collections::HashMap;
+
+pub async fn run(config: &Config) -> Result<()> {
+    let mut sinks = HashMap::new();
+    let mut streams = HashMap::new();
+    for (name, url) in config.plugs.iter() {
+        let (sink, stream) = plug::connect(url).await?;
+        sinks.insert(name.as_str(), sink);
+        streams.insert(name.as_str(), stream);
+    }
+    let mut edges = vec![];
+    for (stream_name, sink_name) in config.links.iter() {
+        let Some(stream) = streams.remove(stream_name.as_str()) else {
+            return Err(anyhow!("No such plug: {stream_name}"));
+        };
+        let Some(sink) = sinks.remove(sink_name.as_str()) else {
+            return Err(anyhow!("No such plug or already used: {sink_name}"));
+        };
+        let edge = stream.forward(sink);
+        edges.push(edge);
+    }
+    future::try_join_all(edges).await?;
+    Ok(())
+}

--- a/kble/src/main.rs
+++ b/kble/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Parser;
 use notalawyer_clap::*;
+use tracing_subscriber::{prelude::*, EnvFilter};
 
 mod app;
 mod plug;
@@ -33,6 +34,15 @@ impl Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(std::io::stderr),
+        )
+        .with(EnvFilter::from_default_env())
+        .init();
+
     let args = Args::parse_with_license_notice(include_notice!());
     let config = args.load_spaghetti_config()?;
     app::run(&config).await?;

--- a/kble/src/main.rs
+++ b/kble/src/main.rs
@@ -6,6 +6,7 @@ use notalawyer_clap::*;
 
 mod plug;
 mod spaghetti;
+mod app;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -30,6 +31,6 @@ impl Args {
 async fn main() -> Result<()> {
     let args = Args::parse_with_license_notice(include_notice!());
     let config = args.load_spaghetti_config()?;
-    config.run().await?;
+    app::run(&config).await?;
     Ok(())
 }

--- a/kble/src/main.rs
+++ b/kble/src/main.rs
@@ -4,9 +4,11 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use notalawyer_clap::*;
 
+mod app;
 mod plug;
 mod spaghetti;
-mod app;
+
+use spaghetti::{Config, Raw};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -22,8 +24,10 @@ impl Args {
             .open(&self.spaghetti)
             .with_context(|| format!("Failed to open {:?}", &self.spaghetti))?;
         let spagetthi_rdr = std::io::BufReader::new(spaghetti_file);
-        serde_yaml::from_reader(spagetthi_rdr)
-            .with_context(|| format!("Unable to parse {:?}", self.spaghetti))
+        let raw: Config<Raw> = serde_yaml::from_reader(spagetthi_rdr)
+            .with_context(|| format!("Unable to parse {:?}", self.spaghetti))?;
+        raw.validate()
+            .with_context(|| format!("Invalid configuration in {:?}", self.spaghetti))
     }
 }
 

--- a/kble/src/spaghetti.rs
+++ b/kble/src/spaghetti.rs
@@ -1,12 +1,75 @@
+use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct Config {
-    pub plugs: HashMap<String, Url>,
-    pub links: HashMap<String, String>,
+pub struct Inner {
+    plugs: HashMap<String, Url>,
+    links: HashMap<String, String>,
+}
+
+#[derive(PartialEq, Debug)]
+pub enum Raw {}
+pub enum Validated {}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct Config<State = Validated> {
+    #[serde(flatten)]
+    inner: Inner,
+    state: std::marker::PhantomData<State>,
+}
+
+impl<'de> serde::Deserialize<'de> for Config<Raw> {
+    fn deserialize<D>(deserializer: D) -> Result<Config<Raw>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner = Inner::deserialize(deserializer)?;
+        Ok(Config::new(inner))
+    }
+}
+
+impl<State> Config<State> {
+    fn new(inner: Inner) -> Self {
+        Config {
+            inner,
+            state: std::marker::PhantomData,
+        }
+    }
+}
+
+impl Config<Raw> {
+    pub fn validate(self) -> Result<Config<Validated>> {
+        use std::collections::HashSet;
+        let mut seen_sinks = HashSet::new();
+
+        for (stream_name, sink_name) in self.inner.links.iter() {
+            if !self.inner.plugs.contains_key(stream_name) {
+                return Err(anyhow!("No such plug: {stream_name}"));
+            }
+            if !self.inner.plugs.contains_key(sink_name) {
+                return Err(anyhow!("No such plug: {sink_name}"));
+            }
+
+            if seen_sinks.contains(sink_name) {
+                return Err(anyhow!("Sink {sink_name} used more than once"));
+            }
+            seen_sinks.insert(sink_name);
+        }
+        Ok(Config::new(self.inner))
+    }
+}
+
+impl Config<Validated> {
+    pub fn plugs(&self) -> &HashMap<String, Url> {
+        &self.inner.plugs
+    }
+
+    pub fn links(&self) -> &HashMap<String, String> {
+        &self.inner.links
+    }
 }
 
 #[cfg(test)]
@@ -18,7 +81,7 @@ mod tests {
     #[test]
     fn test_de() {
         let yaml = "plugs:\n  tfsync: exec:tfsync foo\n  seriald: ws://seriald.local/\nlinks:\n  tfsync: seriald\n";
-        let expected = Config {
+        let inner = Inner {
             plugs: HashMap::from_iter([
                 ("tfsync".to_string(), Url::parse("exec:tfsync foo").unwrap()),
                 (
@@ -28,7 +91,33 @@ mod tests {
             ]),
             links: HashMap::from_iter([("tfsync".to_string(), "seriald".to_string())]),
         };
+        let expected = Config {
+            inner,
+            state: std::marker::PhantomData,
+        };
         let actual = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(expected, actual);
+        actual.validate().unwrap();
+    }
+
+    #[test]
+    fn test_de_invalid_dest() {
+        let yaml = "plugs:\n  tfsync: exec:tfsync foo\n  seriald: ws://seriald.local/\nlinks:\n  tfsync: serialdxxxx\n";
+        let actual: Config<Raw> = serde_yaml::from_str(yaml).unwrap();
+        assert!(actual.validate().is_err());
+    }
+
+    #[test]
+    fn test_de_invalid_source() {
+        let yaml = "plugs:\n  tfsync: exec:tfsync foo\n  seriald: ws://seriald.local/\nlinks:\n  tfsyncxxxx: seriald\n";
+        let actual: Config<Raw> = serde_yaml::from_str(yaml).unwrap();
+        assert!(actual.validate().is_err());
+    }
+
+    #[test]
+    fn test_de_duplicate_sink() {
+        let yaml = "plugs:\n  tfsync: exec:tfsync foo\n  seriald: ws://seriald.local/\nlinks:\n  tfsync: seriald\n  seriald: seriald\n";
+        let actual: Config<Raw> = serde_yaml::from_str(yaml).unwrap();
+        assert!(actual.validate().is_err());
     }
 }

--- a/kble/src/spaghetti.rs
+++ b/kble/src/spaghetti.rs
@@ -1,41 +1,12 @@
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Result};
-use futures::{future, StreamExt};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::plug;
-
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Config {
-    plugs: HashMap<String, Url>,
-    links: HashMap<String, String>,
-}
-
-impl Config {
-    pub async fn run(&self) -> Result<()> {
-        let mut sinks = HashMap::new();
-        let mut streams = HashMap::new();
-        for (name, url) in self.plugs.iter() {
-            let (sink, stream) = plug::connect(url).await?;
-            sinks.insert(name.as_str(), sink);
-            streams.insert(name.as_str(), stream);
-        }
-        let mut edges = vec![];
-        for (stream_name, sink_name) in self.links.iter() {
-            let Some(stream) = streams.remove(stream_name.as_str()) else {
-                return Err(anyhow!("No such plug: {stream_name}"));
-            };
-            let Some(sink) = sinks.remove(sink_name.as_str()) else {
-                return Err(anyhow!("No such plug or already used: {sink_name}"));
-            };
-            let edge = stream.forward(sink);
-            edges.push(edge);
-        }
-        future::try_join_all(edges).await?;
-        Ok(())
-    }
+    pub plugs: HashMap<String, Url>,
+    pub links: HashMap<String, String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
今後の変更の準備として、いくつかの簡単なリファクタリングとtracing-subscriberの設定をする

* `spaghetti::Config::run` を`app::run` に移動
* configファイルの妥当性検証を、configファイル読み込み直後に行う
  * これにより`run` 関数内の "No such plug" エラーは `unreachable!` になる
* tracing-subscriberを設定する
