### PR TITLE
フォワーディングのtraceログを出す

### DIFF
--- a/kble/src/app.rs
+++ b/kble/src/app.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use futures::{future, SinkExt, StreamExt};
 use std::collections::HashMap;
 use tokio::sync::broadcast;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 struct Connection {
     backend: plug::Backend,
@@ -207,10 +207,17 @@ impl<'a> Link<'a> {
                 Ok(data) => data,
             };
 
+            let data_len = data.len();
             if let Err(e) = self.dest.send(data).await {
                 warn!("Error writing to {}: {}", self.dest_name, e);
                 break;
             }
+            trace!(
+                "{} -> {}: {} bytes",
+                self.source_name,
+                self.dest_name,
+                data_len
+            );
         }
         self
     }

--- a/kble/src/main.rs
+++ b/kble/src/main.rs
@@ -47,6 +47,7 @@ async fn main() -> Result<()> {
         )
         .with(EnvFilter::from_default_env())
         .init();
+    tracing::info!("Starting");
 
     let args = Args::parse_with_license_notice(include_notice!());
     let config = args.load_spaghetti_config()?;


### PR DESCRIPTION
end to endの通信が失敗しているとき、どこで止まっているか調査するためのログを追加