### PR TITLE
Close all streams even if any stream closed normally

### DIFF
--- a/kble-serialport/src/main.rs
+++ b/kble-serialport/src/main.rs
@@ -159,7 +159,9 @@ async fn handle_ws(ws: WebSocket, serialport: SerialStream) {
             let chunk = chunk?;
             tx.write_all(&chunk).await?;
         }
+        tx.flush().await?;
         anyhow::Ok(())
     };
-    futures::future::try_join(rx_fut, tx_fut).await.ok();
+    tokio::pin!(rx_fut, tx_fut);
+    futures::future::try_select(rx_fut, tx_fut).await.ok();
 }


### PR DESCRIPTION
WebSocket Client が *正常に* ストリームを閉じた場合、シリアルポートを掴んだままとなり再接続不能になっていました。
kble を SIGINT 等で閉じると WebSocket ストリームは異常終了するため、この問題が顕在化していなかったと推測しています。