### PR TITLE
Update Rust to 1.78.0

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.78.0"


### PR DESCRIPTION
- Renovate のコンテナイメージ内の Rust が新しくなったのか、lockfile を v4 にしてくるようになった
  - https://github.com/arkedge/kble/pull/137/files#r1940462261
  - Rust 1.83.0 で default になったためと思われる: https://github.com/rust-lang/cargo/pull/14595
- lockfile v4 の stabilize は 1.78.0: https://github.com/rust-lang/cargo/pull/12852
  - しかし今は 1.76.0 に固定していた
  - そのため、Renovate PR の CI が突然コケるようになっていた
- Rust 1.76.0 にこだわる理由があるわけではあまり無いので、1.78.0 に更新する