### PR TITLE
fix(kble-eb90): default --buffer-size to the maximum frame size

### DIFF
--- a/kble-eb90/src/main.rs
+++ b/kble-eb90/src/main.rs
@@ -16,11 +16,18 @@ struct Args {
     command: Commands,
 }
 
+/// The largest possible EB90 frame: header + maximum (u16) body + footer.
+/// Defaulting the decode buffer to this guarantees every valid frame fits, so
+/// none is ever dropped for being over-buffer. A smaller `--buffer-size` still
+/// works, but any frame larger than it is skipped and logged as `InvalidLength`
+/// junk (the decoder recovers and keeps processing) rather than emitted.
+const MAX_FRAME_SIZE: usize = eb90::HEADER_SIZE + u16::MAX as usize + eb90::FOOTER_SIZE;
+
 #[derive(Subcommand, Debug)]
 enum Commands {
     Encode,
     Decode {
-        #[clap(long, short, default_value_t = 2048)]
+        #[clap(long, short, default_value_t = MAX_FRAME_SIZE)]
         buffer_size: usize,
     },
 }
@@ -70,6 +77,9 @@ async fn run_decode(buffer_size: usize) -> Result<()> {
             use eb90::codec::Decoded;
             match decoded {
                 Decoded::Frame(frame) => tx.send(frame).await?,
+                // A frame whose declared size exceeds `--buffer-size` is reported
+                // as `InvalidLength` junk and skipped. With the default buffer
+                // (max frame size) this cannot happen for a valid frame.
                 Decoded::Junk(kind) => warn!(?kind, "received junk data"),
             }
         }

--- a/kble-eb90/tests/e2e.rs
+++ b/kble-eb90/tests/e2e.rs
@@ -22,13 +22,6 @@ use tokio::runtime::Runtime;
 /// Upper bound (exclusive) on generated payload lengths.
 const MAX_PAYLOAD_LEN: usize = 2048;
 
-/// `kble-eb90 decode` assembles each whole frame in a fixed-capacity buffer
-/// (`eb90`'s parser never grows it past the initial capacity), so the buffer
-/// must exceed the largest *encoded* frame — payload plus EB90 framing overhead.
-/// A frame larger than this is never emitted, so we give generous headroom above
-/// `MAX_PAYLOAD_LEN` rather than relying on the 2048-byte default.
-const DECODE_BUFFER_SIZE: usize = MAX_PAYLOAD_LEN * 2;
-
 /// Build a `Command` that runs the freshly-built `kble-eb90` binary with the
 /// given subcommand. Cargo exposes the binary path to integration tests of the
 /// same crate via this env var, so no `escargot`/`assert_cmd` is needed.
@@ -51,9 +44,9 @@ async fn encode(payload: Bytes) -> Bytes {
 
 /// Run `frame` through a fresh `decode` process and return the decoded payload.
 async fn decode(frame: Bytes) -> Bytes {
-    let mut cmd = eb90("decode");
-    cmd.arg("--buffer-size").arg(DECODE_BUFFER_SIZE.to_string());
-    let mut dec = Plug::spawn(cmd).await.expect("spawn kble-eb90 decode");
+    let mut dec = Plug::spawn(eb90("decode"))
+        .await
+        .expect("spawn kble-eb90 decode");
     dec.send(frame).await.expect("send to decode");
     let decoded = dec.recv().await.expect("decode produced a frame");
     dec.shutdown().await.expect("decode exits cleanly");
@@ -95,6 +88,16 @@ async fn roundtrips_empty_payload() {
         decoded.is_empty(),
         "empty payload must round-trip to empty, got {decoded:?}"
     );
+}
+
+/// A frame far larger than the old 2048-byte default decode buffer now
+/// round-trips with default settings: the default buffer is the maximum EB90
+/// frame size, so no valid frame is ever dropped as over-buffer.
+#[tokio::test]
+async fn roundtrips_large_payload_with_default_buffer() {
+    let payload = vec![0x5Au8; 10_000];
+    let decoded = roundtrip(&payload).await;
+    assert_eq!(decoded.as_ref(), payload.as_slice());
 }
 
 proptest! {


### PR DESCRIPTION
## Problem

`kble-eb90 decode` assembles each frame in a fixed-capacity buffer. `eb90`'s parser reports any frame whose declared size exceeds that capacity as `InvalidLength` junk and skips it. With the previous **2048-byte default `--buffer-size`**, every frame larger than ~2040 bytes was therefore **silently dropped** (only a `warn!` log) — even though `encode` happily produces frames with bodies up to `u16::MAX` (~64 KiB). Space Packets wrapped to EB90 routinely exceed 2 KiB, so default `decode` would quietly lose them.

(The decoder recovers and keeps processing after the dropped frame — it does not wedge — but the oversized frame's data is gone.)

## Fix

Default `--buffer-size` to the **largest possible EB90 frame**: `HEADER_SIZE + u16::MAX + FOOTER_SIZE` (= 65543 bytes). Since the length field is a `u16`, no valid frame can exceed this, so the default never drops a frame. An explicit smaller `--buffer-size` still skips (and logs) over-large frames, which is now an opt-in trade-off rather than a silent default footgun.

## How it was found

The property-based round-trip E2E tests added in #180 surfaced this. This PR adds a deterministic 10 KiB round-trip (`roundtrips_large_payload_with_default_buffer`) that **fails on the old 2048 default** (the frame is dropped, decode emits nothing) and **passes** now. The `--buffer-size` workaround the E2E tests previously needed is removed, since the default is now correct.

## Test

`cargo test -p kble-eb90` green (5 E2E + unit/doc). `cargo fmt --all --check` and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
