### PR TITLE
feat(kble-test-support): WsPlug in-process ws:// server for orchestrator E2E tests

### DIFF
--- a/kble-test-support/Cargo.toml
+++ b/kble-test-support/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 anyhow.workspace = true
 bytes.workspace = true
 futures-util.workspace = true
-tokio = { workspace = true, features = ["process", "io-util", "time"] }
+tokio = { workspace = true, features = ["process", "io-util", "time", "net"] }
 tokio-tungstenite.workspace = true
 kble-socket = { workspace = true, features = ["tungstenite"] }
 pin-project-lite.workspace = true

--- a/kble-test-support/src/lib.rs
+++ b/kble-test-support/src/lib.rs
@@ -9,6 +9,13 @@
 //! piped stdio, performs no HTTP handshake (just like the orchestrator —
 //! `from_raw_socket` only sets up framing), and hands back a binary
 //! [`SocketSink`]/[`SocketStream`] pair to push bytes in and read bytes out.
+//!
+//! [`WsPlug`] covers the other direction: it stands up an in-process WebSocket
+//! *server* on an ephemeral port so a test can exercise the `kble` orchestrator
+//! binary itself. The orchestrator connects to `ws://` plugs as a client (a
+//! real HTTP handshake via `connect_async`), so a test that wants to inject and
+//! observe the bytes crossing a link can register a [`WsPlug`] as the link's
+//! endpoint and drive it from the outside.
 
 use std::{io, pin::Pin, process::Stdio, task, time::Duration};
 
@@ -19,6 +26,7 @@ use kble_socket::{from_tungstenite, SocketSink, SocketStream};
 use pin_project_lite::pin_project;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
+    net::TcpListener,
     process::{Child, ChildStdin, ChildStdout, Command},
 };
 use tokio_tungstenite::{tungstenite::protocol::Role, WebSocketStream};
@@ -80,13 +88,7 @@ impl Plug {
     /// forever — if nothing arrives within `timeout` or the process closes its
     /// output stream without sending a frame.
     pub async fn recv_timeout(&mut self, timeout: Duration) -> Result<Bytes> {
-        match tokio::time::timeout(timeout, self.stream.next()).await {
-            Ok(Some(frame)) => frame,
-            Ok(None) => Err(anyhow!(
-                "plug closed its output stream without sending a frame"
-            )),
-            Err(_) => Err(anyhow!("plug produced no frame within {timeout:?}")),
-        }
+        next_frame(&mut self.stream, timeout, "plug").await
     }
 
     /// Close the connection and wait for the process to exit.
@@ -120,6 +122,124 @@ impl Plug {
                 ))
             }
         }
+    }
+}
+
+/// Receive the next frame from `stream`, failing — rather than hanging forever
+/// — if nothing arrives within `timeout` or the peer closes the stream without
+/// sending a frame. `peer` names the other end for the error message.
+async fn next_frame(stream: &mut SocketStream, timeout: Duration, peer: &str) -> Result<Bytes> {
+    match tokio::time::timeout(timeout, stream.next()).await {
+        Ok(Some(frame)) => frame,
+        Ok(None) => Err(anyhow!(
+            "{peer} closed its output stream without sending a frame"
+        )),
+        Err(_) => Err(anyhow!("{peer} produced no frame within {timeout:?}")),
+    }
+}
+
+/// An in-process WebSocket server that stands in for a `ws://` plug.
+///
+/// The `kble` orchestrator connects to `ws://` plugs as a client (a real HTTP
+/// handshake via `connect_async`). A test that wants to drive the orchestrator
+/// binary binds one of these on an ephemeral port, drops its [`url`](Self::url)
+/// into the spaghetti `plugs:` map, then [`accept`](Self::accept)s the
+/// orchestrator's connection to get a [`WsPlugConn`] it can push bytes into and
+/// read forwarded bytes out of.
+///
+/// Bind every plug a config references *before* spawning the orchestrator, and
+/// accept them concurrently (e.g. with `tokio::join!`): the orchestrator dials
+/// its plugs one at a time and blocks on each handshake, so accepting them
+/// sequentially can deadlock if its connection order differs from the test's.
+pub struct WsPlug {
+    url: String,
+    listener: TcpListener,
+}
+
+impl WsPlug {
+    /// Bind a server on an ephemeral `127.0.0.1` port.
+    pub async fn bind() -> Result<Self> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .context("failed to bind ws plug listener")?;
+        let port = listener
+            .local_addr()
+            .context("failed to read ws plug local address")?
+            .port();
+        Ok(Self {
+            url: format!("ws://127.0.0.1:{port}/"),
+            listener,
+        })
+    }
+
+    /// The `ws://` URL the orchestrator should connect to for this plug.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Accept the orchestrator's connection and complete the WebSocket
+    /// handshake, yielding a connected endpoint.
+    ///
+    /// Bounded by [`DEFAULT_TIMEOUT`]: if nothing connects — the orchestrator
+    /// failed to start, hit a config parse error, or was never pointed at this
+    /// URL — this fails the test rather than hanging it forever (libtest has no
+    /// per-test timeout).
+    pub async fn accept(self) -> Result<WsPlugConn> {
+        let handshake = async {
+            let (tcp, _peer) = self
+                .listener
+                .accept()
+                .await
+                .context("ws plug never accepted a connection")?;
+            tokio_tungstenite::accept_async(tcp)
+                .await
+                .context("ws plug handshake failed")
+        };
+        let wss = match tokio::time::timeout(DEFAULT_TIMEOUT, handshake).await {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(anyhow!(
+                    "ws plug: nothing connected within {DEFAULT_TIMEOUT:?} \
+                     (did the orchestrator fail to start?)"
+                ))
+            }
+        };
+        let (sink, stream) = from_tungstenite(wss);
+        Ok(WsPlugConn { sink, stream })
+    }
+}
+
+/// A connected in-process `ws://` plug endpoint (see [`WsPlug::accept`]).
+///
+/// To signal end-of-stream — the orchestrator's cue that a link's source is
+/// done — **drop** the connection. That closes the TCP transport, which the
+/// orchestrator reads as EOF. A graceful WebSocket Close frame is not enough:
+/// the orchestrator reads each plug through the read half of a *split* stream
+/// (see `kble/src/plug.rs`), and that half cannot complete the Close handshake
+/// (replying needs the write half), so it never observes the close.
+pub struct WsPlugConn {
+    /// Bytes sent here are delivered to the orchestrator as binary frames.
+    pub sink: SocketSink,
+    /// Yields the binary frames the orchestrator forwards to this endpoint.
+    pub stream: SocketStream,
+}
+
+impl WsPlugConn {
+    /// Send one binary frame to the orchestrator.
+    pub async fn send(&mut self, frame: Bytes) -> Result<()> {
+        self.sink.send(frame).await
+    }
+
+    /// Receive the next frame the orchestrator forwards here, using the default
+    /// deadline.
+    pub async fn recv(&mut self) -> Result<Bytes> {
+        self.recv_timeout(DEFAULT_TIMEOUT).await
+    }
+
+    /// Receive the next frame, failing rather than hanging if none arrives
+    /// within `timeout` or the orchestrator closes this link.
+    pub async fn recv_timeout(&mut self, timeout: Duration) -> Result<Bytes> {
+        next_frame(&mut self.stream, timeout, "ws plug").await
     }
 }
 
@@ -185,5 +305,34 @@ mod tests {
             "unexpected error: {err}"
         );
         // `kill_on_drop` reaps the still-running `sleep` when `plug` drops.
+    }
+
+    /// `WsPlug` must speak a real WebSocket handshake (the orchestrator dials it
+    /// with `connect_async`) and ferry binary frames both ways. Accept and
+    /// connect are driven concurrently because each blocks until the other side
+    /// is handshaking.
+    #[tokio::test]
+    async fn ws_plug_ferries_binary_frames_both_ways() {
+        use tokio_tungstenite::tungstenite::Message;
+
+        let plug = WsPlug::bind().await.expect("bind ws plug");
+        let url = plug.url().to_string();
+
+        let (conn, client) = tokio::join!(plug.accept(), tokio_tungstenite::connect_async(url));
+        let mut conn = conn.expect("accept orchestrator-side connection");
+        let (mut client, _resp) = client.expect("client connects to ws plug");
+
+        // server -> client (orchestrator forwarding *to* this plug)
+        conn.send(Bytes::from_static(b"down")).await.expect("send");
+        let down = client.next().await.expect("client recv").expect("ws msg");
+        assert_eq!(down.into_data(), b"down");
+
+        // client -> server (this plug feeding the orchestrator)
+        client
+            .send(Message::Binary(b"up".to_vec()))
+            .await
+            .expect("client send");
+        let up = conn.recv().await.expect("server recv");
+        assert_eq!(up.as_ref(), b"up");
     }
 }


### PR DESCRIPTION
## What

Adds **`WsPlug`** to `kble-test-support`: an in-process WebSocket *server* on an ephemeral port, the test infrastructure needed to drive the `kble` orchestrator binary end-to-end.

This PR is **infra only**. It is split from the work it enables:
- the orchestrator bug it surfaced → **#184** (`fix(kble)`)
- the orchestrator E2E tests that use it → follow-up tests PR (opened once #184 + this land)

## Why

The orchestrator launches `exec:` plugs internally, so a test can't observe the bytes crossing a link from the outside. But the orchestrator also connects to `ws://` plugs *as a client* (a real HTTP handshake via `connect_async`). That's the seam: a test binds a `WsPlug`, drops its URL into the spaghetti config, and `accept()`s the orchestrator's connection to get a `WsPlugConn` it can push bytes into and read forwarded bytes out of.

`WsPlug` reuses the same `kble_socket::from_tungstenite` machinery the real plugs use, so the framing path under test is the production one.

## Notes

- `accept()` is bounded by `DEFAULT_TIMEOUT`, so a non-connecting orchestrator (failed start, config error) fails the test instead of hanging it — matching the crate's existing stance.
- Dropping a `WsPlugConn` closes its TCP transport, which is how a `ws://` plug signals end-of-stream; a graceful WS Close frame alone isn't observed by the orchestrator's split read half (documented on the type).
- The `recv`-with-timeout logic `Plug` already had is factored into a shared `next_frame` helper used by both endpoints.

Covered by the crate's own unit tests (`ws_plug_ferries_binary_frames_both_ways`, `recv_times_out_on_a_silent_plug`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
