### PR TITLE
ci: pin GitHub Actions to explicit minor/patch versions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,8 +9,8 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: reviewdog/action-actionlint@v1
+      - uses: actions/checkout@v4.2.2
+      - uses: reviewdog/action-actionlint@v1.72.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
   verify-crate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
 


### PR DESCRIPTION
## 概要

GitHub Actions の `uses:` のうち、メジャータグ（`@v4` など）だけで参照していたものを minor/patch まで明示的にピン留めします。メジャータグは可変な参照で、メンテナが付け替えると同じ参照でも実行されるコードが変わりうる（サプライチェーン上のリスク）ためです。

すでに minor/patch まで固定済みのアクション（`Swatinem/rust-cache`, `sksat/action-clippy`, `actions/upload-artifact`, `actions/download-artifact`, `softprops/action-gh-release`, release.yml の `actions/checkout@v4.2.2`）はそのままです。

## 変更内容

| アクション | before | after |
| --- | --- | --- |
| `actions/checkout` (rust.yml, actionlint.yml) | `@v4` | `@v4.2.2` |
| `reviewdog/action-actionlint` (actionlint.yml) | `@v1` | `@v1.72.0` |

- `actions/checkout` は release.yml で既に使われている `v4.2.2` に揃えてリポジトリ全体で一致させています。
- `reviewdog/action-actionlint` は最新の `v1.72.0` にピン留め。

## 変更しなかったもの

- `dtolnay/rust-toolchain@v1` は `v1` ロールタグしか公開しておらず、minor/patch タグが存在しないため `@v1` のままにしています（このアクションは `v1` + `toolchain:` 入力で使うのが推奨形）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)