### PR TITLE
fix(kble-dump): exit after replay completes, with record/replay E2E test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "clap",
  "futures",
  "kble-socket",
+ "kble-test-support",
  "miniz_oxide",
  "notalawyer",
  "notalawyer-build",

--- a/kble-dump/Cargo.toml
+++ b/kble-dump/Cargo.toml
@@ -28,3 +28,6 @@ rmp-serde = "1.3.0"
 chrono = { version = "0.4.38", features = ["serde"] }
 miniz_oxide = "0.7.3"
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+kble-test-support = { path = "../kble-test-support" }

--- a/kble-dump/src/main.rs
+++ b/kble-dump/src/main.rs
@@ -32,8 +32,24 @@ async fn main() -> Result<()> {
 
     let args = Args::parse_with_license_notice(include_notice!());
     match args.command {
+        // `record` ends only when its stdin closes, so it never hits the hang
+        // below; returning normally also lets its dump-file writes flush during
+        // runtime shutdown (an explicit `process::exit` here could truncate the
+        // last record).
         Commands::Record { output_dir } => run_record(&output_dir).await,
-        Commands::Replay { input_file } => run_replay(&input_file).await,
+        Commands::Replay { input_file } => {
+            let result = run_replay(&input_file).await;
+            if let Err(e) = &result {
+                tracing::error!("replay failed: {e}");
+            }
+            // `replay` finishes when its input *file* is exhausted while a
+            // spawned task is still blocked reading stdin via
+            // `kble_socket::from_stdio` (`tokio::io::stdin()`, whose blocking
+            // read cannot be cancelled). Returning to the runtime would block
+            // shutdown on that thread and hang the process after playback, so
+            // exit explicitly.
+            std::process::exit(i32::from(result.is_err()))
+        }
     }
 }
 

--- a/kble-dump/tests/e2e.rs
+++ b/kble-dump/tests/e2e.rs
@@ -1,0 +1,115 @@
+//! End-to-end tests for the `kble-dump` record/replay plug.
+//!
+//! `kble-dump record <dir>` writes each frame it receives to a dump file and
+//! echoes it back; `kble-dump replay <file>` plays a dump file's frames back
+//! out (honoring the recorded inter-frame timing). The test drives both as real
+//! processes over the WebSocket-over-stdio protocol via
+//! [`kble_test_support::Plug`], recording a handful of frames and then replaying
+//! them.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use bytes::Bytes;
+use kble_test_support::Plug;
+use tokio::process::Command;
+
+/// Build a `Command` running the freshly-built `kble-dump` binary.
+fn kble_dump(args: &[&str]) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_kble-dump"));
+    cmd.args(args);
+    cmd
+}
+
+/// A fresh, uniquely-named directory under the per-test-binary temp dir Cargo
+/// provides.
+fn unique_tmp_dir(prefix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    // `CARGO_TARGET_TMPDIR` persists across test runs and the dir is never
+    // cleaned, so a pid (which the OS can recycle) + counter name could collide
+    // with a stale dir from an earlier run. Start each one empty so
+    // `find_dump_file` sees only this run's dump.
+    let dir =
+        Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!("{prefix}-{}-{n}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// The single `*.bin` dump file `record` wrote into `dir`.
+fn find_dump_file(dir: &Path) -> PathBuf {
+    let mut bins: Vec<PathBuf> = std::fs::read_dir(dir)
+        .expect("read dump dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "bin"))
+        .collect();
+    assert_eq!(
+        bins.len(),
+        1,
+        "expected exactly one dump file, got {bins:?}"
+    );
+    bins.pop().unwrap()
+}
+
+/// Record `frames` to a fresh dump file and return its path. `record` echoes
+/// each frame back, so we also assert the echo here; closing the input ends the
+/// recording and the process must exit cleanly.
+async fn record_dump(frames: &[&[u8]]) -> PathBuf {
+    let dir = unique_tmp_dir("kble-dump-rec");
+    let mut plug = Plug::spawn(kble_dump(&["record", dir.to_str().unwrap()]))
+        .await
+        .expect("spawn kble-dump record");
+
+    for frame in frames {
+        plug.send(Bytes::copy_from_slice(frame))
+            .await
+            .expect("record send");
+        let echo = plug.recv().await.expect("record echoes the frame");
+        assert_eq!(echo.as_ref(), *frame, "record must echo the input frame");
+    }
+
+    plug.shutdown()
+        .await
+        .expect("record exits cleanly when its input closes");
+    find_dump_file(&dir)
+}
+
+/// Record a few frames, then replay the dump file: replay must emit the same
+/// frames in order and then **exit** once the file is exhausted — even though
+/// its WS input is still open. (Regression: replay drained stdin on a spawned
+/// task using `tokio::io::stdin()`'s uncancellable blocking read, which blocked
+/// runtime shutdown, so replay hung after playback instead of terminating.)
+#[tokio::test]
+async fn replays_recorded_frames_and_exits() {
+    let frames: [&[u8]; 3] = [b"first frame", b"the second one", b"third!"];
+    let dump = record_dump(&frames).await;
+
+    let mut plug = Plug::spawn(kble_dump(&["replay", dump.to_str().unwrap()]))
+        .await
+        .expect("spawn kble-dump replay");
+
+    for expected in &frames {
+        let got = plug.recv().await.expect("replay emits a frame");
+        assert_eq!(got.as_ref(), *expected, "replay must reproduce the frame");
+    }
+
+    // The file is exhausted, so replay should terminate and close its output.
+    let err = plug
+        .recv_timeout(Duration::from_secs(5))
+        .await
+        .expect_err("replay output should end once the dump file is exhausted");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("reset") || msg.contains("closed"),
+        "replay should exit after the file ends (reset/eof), got: {err}"
+    );
+
+    // Reap the now-exited process and confirm a clean exit status (mirroring the
+    // kble-tcp lifecycle test); the WS sink is already dead, so closing it is a
+    // no-op.
+    plug.shutdown()
+        .await
+        .expect("replay should have exited cleanly once the dump file ended");
+}


### PR DESCRIPTION
## What

E2E tests for **`kble-dump`** (record/replay), and the **replay shutdown hang they surfaced** — the same root cause as the kble-tcp fix (#186).

Two commits: `fix(kble-dump)` then `test(kble-dump)`.

## The bug (found by review, now caught by a test)

`replay` finishes when its input **file** is exhausted, while a spawned task drains stdin via `kble_socket::from_stdio` (`tokio::io::stdin()`). That blocking read thread can't be cancelled mid-read, so returning to the runtime blocked shutdown on it — **`kble-dump replay` hung after playback** instead of exiting, leaving its WS output open so the orchestrator never saw it finish.

This one was first spotted by **code review** (during #186) — there was no test, so CI stayed green over it. This PR adds the test (which **hangs / `no frame within 5s` without the fix**) and the fix.

Fix: `std::process::exit` **on the `replay` branch only**, and log the error instead of dropping it.

> ⚠️ Review caught that applying `process::exit` to the whole `main` (as in #186) would regress **`record`**: it writes a dump file, and `process::exit` would abandon tokio's in-flight `File` write → possible truncation of the last record. `record` also doesn't need the fix (it ends when stdin closes, no hang). So the exit is scoped to `replay`; `record` returns normally and its writes flush during the normal runtime shutdown.

## The test

`replays_recorded_frames_and_exits`: records 3 frames (asserting `record` echoes each and exits cleanly on input close), then replays the dump file and asserts it reproduces the frames **and exits** once the file is exhausted. Uses `record` to produce the dump file, so it isn't coupled to the on-disk format.

`cargo test`, `cargo fmt --all --check`, clippy all green.

> Note: the underlying `tokio::io::stdin()` issue is shared by stdio plugs that can finish for a reason other than stdin closing (kble-tcp #186, now kble-dump). Centralizing the workaround in `kble_socket` could be a future cleanup. A pre-existing, out-of-scope item also remains: `replay`'s `while let Ok(..) = decode(..)` treats a corrupt dump file like clean EOF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
