### PR TITLE
feat(kble-socket): cancellable pipe stdin; drop per-plug process::exit workarounds

### DIFF
--- a/kble-dump/src/main.rs
+++ b/kble-dump/src/main.rs
@@ -31,25 +31,15 @@ async fn main() -> Result<()> {
         .init();
 
     let args = Args::parse_with_license_notice(include_notice!());
+    // `replay` finishes when its input file is exhausted while a spawned task is
+    // still reading stdin. With the orchestrator/test-harness's piped stdio,
+    // `kble_socket::from_stdio` reads it cancellably, so that no longer hangs
+    // shutdown; both subcommands just return and let the runtime shut down
+    // normally (which also flushes `record`'s dump-file writes). A non-pipe stdin
+    // (e.g. a terminal) still uses the blocking reader.
     match args.command {
-        // `record` ends only when its stdin closes, so it never hits the hang
-        // below; returning normally also lets its dump-file writes flush during
-        // runtime shutdown (an explicit `process::exit` here could truncate the
-        // last record).
         Commands::Record { output_dir } => run_record(&output_dir).await,
-        Commands::Replay { input_file } => {
-            let result = run_replay(&input_file).await;
-            if let Err(e) = &result {
-                tracing::error!("replay failed: {e}");
-            }
-            // `replay` finishes when its input *file* is exhausted while a
-            // spawned task is still blocked reading stdin via
-            // `kble_socket::from_stdio` (`tokio::io::stdin()`, whose blocking
-            // read cannot be cancelled). Returning to the runtime would block
-            // shutdown on that thread and hang the process after playback, so
-            // exit explicitly.
-            std::process::exit(i32::from(result.is_err()))
-        }
+        Commands::Replay { input_file } => run_replay(&input_file).await,
     }
 }
 

--- a/kble-socket/Cargo.toml
+++ b/kble-socket/Cargo.toml
@@ -19,6 +19,6 @@ axum.workspace = true
 bytes.workspace = true
 
 [features]
-stdio = ["tokio/io-std", "dep:pin-project-lite"]
+stdio = ["tokio/io-std", "tokio/net", "dep:pin-project-lite"]
 tungstenite = ["dep:tokio-tungstenite"]
 axum = ["axum/ws"]

--- a/kble-socket/src/stdio.rs
+++ b/kble-socket/src/stdio.rs
@@ -6,12 +6,157 @@ use tokio::io::{AsyncRead, AsyncWrite, Stdin, Stdout};
 
 use crate::{SocketSink, SocketStream};
 
+/// Build a binary socket over this process's stdin/stdout (the WebSocket
+/// *server* side; the orchestrator is the client).
+///
+/// Pipe stdin/stdout (how a plug is launched) are read/written cancellably so
+/// the plug shuts down cleanly even when it ends for a reason other than stdin
+/// closing; a terminal/file or non-Unix falls back to blocking `tokio::io`. See
+/// [`StdinReader`] for the why.
 #[cfg(feature = "tungstenite")]
 pub async fn from_stdio() -> (SocketSink, SocketStream) {
     use tokio_tungstenite::{tungstenite::protocol::Role, WebSocketStream};
-    let stdio = Stdio::new(tokio::io::stdin(), tokio::io::stdout());
+    let stdio = AutoStdio::new();
     let wss = WebSocketStream::from_raw_socket(stdio, Role::Server, None).await;
     crate::from_tungstenite(wss)
+}
+
+/// The stdin half of [`from_stdio`]'s socket.
+///
+/// `tokio::io::stdin()` reads on a blocking thread that can't be cancelled, so a
+/// plug that ends for a reason other than stdin closing (a `kble-tcp` peer
+/// disconnecting, a `kble-dump replay` file ending) would hang on runtime
+/// shutdown. When stdin is a pipe (plugs launched by the orchestrator or test
+/// harness) read it via a cancellable `pipe::Receiver`; else fall back to the
+/// blocking reader. (Needs an IO runtime; sets the pipe fd non-blocking.)
+#[cfg(feature = "tungstenite")]
+enum StdinReader {
+    #[cfg(unix)]
+    Pipe(tokio::net::unix::pipe::Receiver),
+    Blocking(Stdin),
+}
+
+#[cfg(feature = "tungstenite")]
+impl StdinReader {
+    fn new() -> Self {
+        #[cfg(unix)]
+        if let Some(rx) = unix_pipe_stdin() {
+            return Self::Pipe(rx);
+        }
+        Self::Blocking(tokio::io::stdin())
+    }
+}
+
+/// Wrap a *duplicate* of fd 0 as a cancellable pipe reader (so dropping it never
+/// closes the real stdin). `from_owned_fd` accepts only a readable pipe and sets
+/// it non-blocking — a non-pipe yields `InvalidInput`, i.e. "fall back". The
+/// non-blocking flag is on the shared fd, so the process's stdin is non-blocking
+/// afterwards (fine: `from_stdio` owns it).
+#[cfg(all(unix, feature = "tungstenite"))]
+fn unix_pipe_stdin() -> Option<tokio::net::unix::pipe::Receiver> {
+    use std::os::fd::AsFd;
+    let dup = std::io::stdin().as_fd().try_clone_to_owned().ok()?;
+    tokio::net::unix::pipe::Receiver::from_owned_fd(dup).ok()
+}
+
+/// The stdout half, mirroring [`StdinReader`]. `tokio::io::stdout()` writes on
+/// the same kind of uncancellable blocking thread, so if a plug ends while a
+/// write is parked on a full pipe (the orchestrator stopped reading), runtime
+/// shutdown would hang there. When stdout is a pipe, write via a cancellable
+/// `pipe::Sender`. (Ordinary backpressure is unaffected — the write just resumes
+/// once the reader drains.)
+#[cfg(feature = "tungstenite")]
+enum StdoutWriter {
+    #[cfg(unix)]
+    Pipe(tokio::net::unix::pipe::Sender),
+    Blocking(Stdout),
+}
+
+#[cfg(feature = "tungstenite")]
+impl StdoutWriter {
+    fn new() -> Self {
+        #[cfg(unix)]
+        if let Some(tx) = unix_pipe_stdout() {
+            return Self::Pipe(tx);
+        }
+        Self::Blocking(tokio::io::stdout())
+    }
+}
+
+/// Wrap stdout (fd 1) as a cancellable pipe writer, or `None` to fall back.
+/// See [`unix_pipe_stdin`] for the fd-duplication and non-blocking caveats.
+#[cfg(all(unix, feature = "tungstenite"))]
+fn unix_pipe_stdout() -> Option<tokio::net::unix::pipe::Sender> {
+    use std::os::fd::AsFd;
+    let dup = std::io::stdout().as_fd().try_clone_to_owned().ok()?;
+    tokio::net::unix::pipe::Sender::from_owned_fd(dup).ok()
+}
+
+/// stdin + stdout (each cancellable when a pipe) as one duplex stream. Every
+/// half is `Unpin`, so the trait impls project via `get_mut`, not `pin_project`.
+#[cfg(feature = "tungstenite")]
+struct AutoStdio {
+    stdin: StdinReader,
+    stdout: StdoutWriter,
+}
+
+#[cfg(feature = "tungstenite")]
+impl AutoStdio {
+    fn new() -> Self {
+        Self {
+            stdin: StdinReader::new(),
+            stdout: StdoutWriter::new(),
+        }
+    }
+}
+
+#[cfg(feature = "tungstenite")]
+impl AsyncRead for AutoStdio {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> task::Poll<io::Result<()>> {
+        match &mut self.get_mut().stdin {
+            #[cfg(unix)]
+            StdinReader::Pipe(rx) => Pin::new(rx).poll_read(cx, buf),
+            StdinReader::Blocking(stdin) => Pin::new(stdin).poll_read(cx, buf),
+        }
+    }
+}
+
+#[cfg(feature = "tungstenite")]
+impl AsyncWrite for AutoStdio {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &[u8],
+    ) -> task::Poll<io::Result<usize>> {
+        match &mut self.get_mut().stdout {
+            #[cfg(unix)]
+            StdoutWriter::Pipe(tx) => Pin::new(tx).poll_write(cx, buf),
+            StdoutWriter::Blocking(stdout) => Pin::new(stdout).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<io::Result<()>> {
+        match &mut self.get_mut().stdout {
+            #[cfg(unix)]
+            StdoutWriter::Pipe(tx) => Pin::new(tx).poll_flush(cx),
+            StdoutWriter::Blocking(stdout) => Pin::new(stdout).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> task::Poll<io::Result<()>> {
+        match &mut self.get_mut().stdout {
+            #[cfg(unix)]
+            StdoutWriter::Pipe(tx) => Pin::new(tx).poll_shutdown(cx),
+            StdoutWriter::Blocking(stdout) => Pin::new(stdout).poll_shutdown(cx),
+        }
+    }
 }
 
 pin_project! {

--- a/kble-tcp/src/main.rs
+++ b/kble-tcp/src/main.rs
@@ -48,23 +48,14 @@ async fn main() -> Result<()> {
         anyhow::Ok(())
     };
 
-    let result = tokio::select! {
-        // Deterministic winner if both sides close in the same poll: the exit
-        // code and any logged error are then reproducible.
+    // Either side closing ends the bridge; `biased` makes the winner
+    // deterministic when both close in the same poll. With the piped stdin/stdout
+    // a plug has under the orchestrator, `kble_socket::from_stdio` is cancellable,
+    // so returning here lets the runtime shut down cleanly. Any `Err` is reported
+    // by `main`'s `Termination` impl.
+    tokio::select! {
         biased;
         r = to_tcp => r,
         r = from_tcp => r,
-    };
-    if let Err(e) = &result {
-        tracing::error!("bridge terminated with error: {e}");
     }
-
-    // `kble_socket::from_stdio` reads via `tokio::io::stdin()`, whose blocking
-    // read thread cannot be cancelled mid-read. The bridge can legitimately
-    // finish via its TCP side (`from_tcp` hits EOF) while stdin is still open;
-    // returning to the runtime would then block shutdown on that stuck thread,
-    // so a closed TCP peer would never terminate us (and our WS output would
-    // stay open, hiding the disconnect from the orchestrator). Exit explicitly
-    // so either side closing promptly ends the process.
-    std::process::exit(i32::from(result.is_err()))
 }


### PR DESCRIPTION
## What

Fixes the **root cause** of the shutdown hang that `kble-tcp` (#186) and `kble-dump replay` (#188) each worked around with `std::process::exit`, by making `kble_socket::from_stdio` read/write pipe **stdin *and* stdout** cancellably. Then removes both per-plug workarounds.

3 commits: `feat(kble-socket)` + `refactor(kble-tcp)` + `refactor(kble-dump)`.

## Root cause

`from_stdio` used `tokio::io::stdin()`/`stdout()`, which read/write on dedicated **blocking threads that cannot be cancelled**. When a plug finishes for a reason other than its stdin closing (a kble-tcp peer disconnecting, a replay file ending), a parked stdin read — **or a stdout write parked on a full pipe** (orchestrator stopped reading) — blocks the runtime from shutting down → the process hangs and its WS output never closes.

## Fix

When stdin/stdout are **pipes** (always true for a plug launched by the orchestrator or the test harness), read/write them through epoll-backed `tokio::net::unix::pipe::{Receiver, Sender}`, which drop cleanly. Plugs then just `return` from `main` — no `process::exit` anywhere. A **duplicate** of fd 0 / fd 1 is handed to each half (`as_fd().try_clone_to_owned()`), so dropping it never closes the real stdin/stdout. Non-pipe (terminal/file) or non-Unix → **falls back** to `tokio::io::stdin()`/`stdout()`.

Designed and reviewed with `smart-friend`/Codex; the **stdout** half was added after Codex's review flagged that removing `process::exit` also exposed a stdout-write hang.

## Is this breaking?

**API: no change** (`from_stdio` signature + public `Stdio` kept; private `AutoStdio` internally).

**Behavior — non-breaking for kble**, proven by the full E2E suite passing (every plug exercises the new `from_stdio`: eb90 incl. the orchestrator multi-hop, c2a, tcp, dump). Documented edge notes:
- Pipe path **requires an IO-enabled runtime** (every plug uses `#[tokio::main]` full) and sets stdin/stdout **non-blocking** (shared OFD — only matters if something reads/writes `std::io::std{in,out}()` directly; no plug does).
- **Non-pipe fallback** (e.g. running a plug interactively from a *terminal*) keeps the old blocking behavior, so a plug that finishes via a non-stdin reason on a terminal could still hang — but these plugs are orchestrator components (always piped stdio); a file-redirect hits EOF and doesn't hang. Accepted + documented.

## Verification

- **Full `cargo test` green** — no regression across all plugs + orchestrator.
- **Root-cause proof**: with the plugs' `process::exit` removed but the kble-socket fix reverted, kble-tcp & kble-dump lifecycle tests **hang (`no frame within 5s`)**; with the fix, both pass instantly.

`cargo fmt --all --check` + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
