### PR TITLE
fix(kble-socket): compile with features = ["stdio"] alone

### DIFF
--- a/kble-socket/src/lib.rs
+++ b/kble-socket/src/lib.rs
@@ -10,7 +10,12 @@ pub type SocketStream = Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + 'stati
 #[cfg(feature = "stdio")]
 mod stdio;
 #[cfg(feature = "stdio")]
-pub use stdio::{from_stdio, Stdio};
+pub use stdio::Stdio;
+// `from_stdio` builds a WebSocket, so it also needs `tungstenite`. Gate the
+// re-export on both features so `features = ["stdio"]` alone still compiles
+// (giving the `Stdio` byte-stream adapter without `from_stdio`).
+#[cfg(all(feature = "stdio", feature = "tungstenite"))]
+pub use stdio::from_stdio;
 
 #[cfg(feature = "tungstenite")]
 mod tungstenite;


### PR DESCRIPTION
## What

Fixes a **pre-existing** feature-flag bug: `kble-socket` with `features = ["stdio"]` (without `tungstenite`) failed to compile.

## The bug

`lib.rs` re-exported `from_stdio` whenever `stdio` was enabled:
```rust
#[cfg(feature = "stdio")]
pub use stdio::{from_stdio, Stdio};
```
But `from_stdio` is `#[cfg(feature = "tungstenite")]` (it builds a `WebSocketStream`). So `stdio` alone gave `error[E0432]: unresolved import stdio::from_stdio`.

## Fix

Gate the `from_stdio` re-export on **both** features; `stdio` alone still provides the `Stdio` byte-stream adapter:
```rust
#[cfg(feature = "stdio")]
pub use stdio::Stdio;
#[cfg(all(feature = "stdio", feature = "tungstenite"))]
pub use stdio::from_stdio;
```

## Notes

- **Pre-existing**, unrelated to #189 (cancellable stdin). Split out per review so #189 stays focused; touches only `lib.rs`, so no conflict with #189.
- The kble plugs all enable `stdio` + `tungstenite`, so this changes nothing for them — it just unbreaks the `stdio`-only combo.
- Verified: `cargo build -p kble-socket --no-default-features --features stdio` and `--features stdio,tungstenite` both succeed; full `cargo test` green.
- Minor: a `stdio`-only build still emits an unused-import warning for `from_stdio`'s types (in `stdio.rs`); not hit in CI (which builds `stdio`+`tungstenite`), can be tidied alongside the `stdio.rs` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
