### PR TITLE
ci: check the feature powerset with cargo-hack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,5 +49,17 @@ jobs:
       - name: format
         run: cargo fmt --all --check
 
+      # The plugs always enable kble-socket with `stdio` + `tungstenite`, so a
+      # workspace build never exercises a single feature on its own. Check every
+      # feature combination so a crate that advertises a feature can't ship one
+      # that fails to compile by itself.
+      - name: install cargo-hack
+        uses: taiki-e/install-action@cde8c9e634f4a17bc06b61413ac0ef75450eac46 # v2.81.4
+        with:
+          tool: cargo-hack
+
+      - name: check feature powerset
+        run: cargo hack check --feature-powerset --no-dev-deps --workspace
+
       - name: unit test
         run: cargo test


### PR DESCRIPTION
## What

Add a `cargo hack check --feature-powerset` step to CI so every feature combination of every workspace crate is compiled.

## Why

The plugs always pull in `kble-socket` with **both** `stdio` and `tungstenite`. Thanks to Cargo's feature unification, a normal `cargo test` over the workspace therefore *never* builds `kble-socket` with a single feature on its own — so a crate can advertise a feature that fails to compile by itself and CI stays green.

That is exactly what happened: `kble-socket` with **`stdio` alone** (no `tungstenite`) has failed to compile since the repo was first opened (`7c463ac`, 2023-04-12):

```
error[E0432]: unresolved import `stdio::from_stdio`
```

`from_stdio` is `#[cfg(feature = "tungstenite")]` but was re-exported under `#[cfg(feature = "stdio")]`. #190 fixes the bug; this PR adds the guard that would have caught it (and will catch the next one).

## Demonstrating the catch (RED → GREEN)

`cargo hack check --feature-powerset --no-dev-deps -p kble-socket` on the current `main`:

```
running `cargo check --no-default-features --features stdio` on kble-socket (4/8)
error[E0432]: unresolved import `stdio::from_stdio`
error: could not compile `kble-socket` (lib) due to 1 previous error
```

With #190's fix applied, all 15 workspace runs (incl. kble-socket's 8 combos) pass.

> **This PR's own CI is intentionally RED right now** — it is running the new check against `main`, which still has the bug. It goes green once **#190** merges and this branch is rebased. That red is the demonstration, not a defect.

## Notes

- `kble-socket` is the only crate with `[features]`, so the powerset is just its 2³ = 8 combinations; other members are checked once (no features). No combinatorial blowup.
- cargo-hack is installed via `taiki-e/install-action` (a **prebuilt binary**) rather than `cargo install`, because the latest cargo-hack's MSRV (1.85) already exceeds this repo's pinned toolchain (1.78). The prebuilt binary is toolchain-independent; the underlying `cargo check` still runs under the pinned 1.78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)