### PR TITLE
test(kble-socket): round-trip the from_axum / from_tungstenite adapters

### DIFF
--- a/kble-socket/Cargo.toml
+++ b/kble-socket/Cargo.toml
@@ -22,3 +22,16 @@ bytes.workspace = true
 stdio = ["tokio/io-std", "tokio/net", "dep:pin-project-lite"]
 tungstenite = ["dep:tokio-tungstenite"]
 axum = ["axum/ws"]
+
+# Integration tests exercise the adapters in isolation: `from_tungstenite` over
+# an in-memory duplex, and `from_axum` against a real (in-process) axum server
+# driven by a real WebSocket client. They run when the `tungstenite` + `axum`
+# features are enabled (as they are in a workspace build). The extra axum
+# features give the in-process server (`tokio`/`http1`), and tokio-tungstenite is
+# the client.
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util", "net", "time"] }
+tokio-tungstenite.workspace = true
+axum = { workspace = true, features = ["tokio", "http1", "ws"] }
+futures-util.workspace = true
+bytes.workspace = true

--- a/kble-socket/tests/adapters.rs
+++ b/kble-socket/tests/adapters.rs
@@ -1,0 +1,105 @@
+//! Adapter-level tests for the externally-facing entry points: each converts a
+//! transport's WebSocket into the binary [`kble_socket::SocketSink`] /
+//! [`SocketStream`] pair, and these tests round-trip a frame through each one in
+//! isolation. They exist so that an axum / tokio-tungstenite bump (#174) that
+//! breaks an adapter fails *here*, pointing at the boundary, rather than only
+//! surfacing as a confusing failure somewhere downstream.
+//!
+//! Enabled when both `tungstenite` and `axum` are on, as in a workspace build.
+
+#![cfg(all(feature = "tungstenite", feature = "axum"))]
+
+use bytes::Bytes;
+use futures_util::{SinkExt, StreamExt};
+
+/// `from_tungstenite`: bytes round-trip both ways between the adapter and a raw
+/// tokio-tungstenite peer connected over an in-memory duplex (no sockets, no
+/// HTTP handshake — `from_raw_socket` just sets up framing per role).
+#[tokio::test]
+async fn from_tungstenite_round_trips_binary_frames() {
+    use tokio_tungstenite::tungstenite::protocol::Role;
+    use tokio_tungstenite::tungstenite::Message;
+    use tokio_tungstenite::WebSocketStream;
+
+    let (server_io, client_io) = tokio::io::duplex(64 * 1024);
+    let server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+    let mut client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+    let (mut sink, mut stream) = kble_socket::from_tungstenite(server);
+
+    // peer -> adapter stream
+    client
+        .send(Message::Binary(b"to the adapter".to_vec()))
+        .await
+        .expect("peer sends a binary frame");
+    let got = stream
+        .next()
+        .await
+        .expect("adapter stream yields a frame")
+        .expect("frame is not an error");
+    assert_eq!(&got[..], b"to the adapter");
+
+    // adapter sink -> peer (a binary frame, per the adapter's encoding)
+    sink.send(Bytes::from_static(b"from the adapter"))
+        .await
+        .expect("adapter sink accepts a frame");
+    match client
+        .next()
+        .await
+        .expect("peer receives a frame")
+        .expect("frame is not an error")
+    {
+        Message::Binary(b) => assert_eq!(&b[..], b"from the adapter"),
+        other => panic!("expected a binary frame, got: {other:?}"),
+    }
+}
+
+/// `from_axum`: bytes round-trip through a real (in-process) axum server whose
+/// handler echoes via the adapter, driven by a real tokio-tungstenite client
+/// that performs the actual HTTP upgrade.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn from_axum_round_trips_binary_frames() {
+    use axum::extract::ws::WebSocketUpgrade;
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
+    use tokio_tungstenite::tungstenite::Message;
+
+    async fn echo(upgrade: WebSocketUpgrade) -> Response {
+        upgrade.on_upgrade(|ws| async move {
+            let (mut sink, mut stream) = kble_socket::from_axum(ws);
+            // Echo every frame back through the adapter's sink.
+            while let Some(Ok(frame)) = stream.next().await {
+                if sink.send(frame).await.is_err() {
+                    break;
+                }
+            }
+        })
+    }
+
+    let app = Router::new().route("/", get(echo));
+    let server = axum::Server::bind(&"127.0.0.1:0".parse().unwrap()).serve(app.into_make_service());
+    let addr = server.local_addr();
+    tokio::spawn(async move {
+        server.await.expect("axum server runs");
+    });
+
+    let (mut client, _resp) = tokio_tungstenite::connect_async(format!("ws://{addr}/"))
+        .await
+        .expect("websocket upgrade against the echo server");
+
+    client
+        .send(Message::Binary(b"echo me".to_vec()))
+        .await
+        .expect("client sends a binary frame");
+    match client
+        .next()
+        .await
+        .expect("client receives the echo")
+        .expect("frame is not an error")
+    {
+        Message::Binary(b) => assert_eq!(&b[..], b"echo me"),
+        other => panic!("expected a binary echo, got: {other:?}"),
+    }
+
+    client.close(None).await.ok();
+}

--- a/kble-socket/tests/adapters.rs
+++ b/kble-socket/tests/adapters.rs
@@ -5,27 +5,24 @@
 //! breaks an adapter fails *here*, pointing at the boundary, rather than only
 //! surfacing as a confusing failure somewhere downstream.
 //!
-//! Enabled when both `tungstenite` and `axum` are on, as in a workspace build.
+//! Each test is gated on just the feature its adapter needs, so `tungstenite`
+//! and `axum` can be exercised independently (e.g. `--features tungstenite`).
 //!
-//! Every receive/connect await is bounded by [`TIMEOUT`]: a regression that
-//! stops an adapter producing frames should fail fast at the offending line, not
-//! hang the test (and CI) indefinitely.
-
-#![cfg(all(feature = "tungstenite", feature = "axum"))]
-
-use std::time::Duration;
-
-use bytes::Bytes;
-use futures_util::{SinkExt, StreamExt};
+//! Every await is bounded by [`TIMEOUT`]: a regression that stalls an adapter
+//! should fail fast at the offending line, not hang the test (and CI).
 
 /// Upper bound on how long any single round-trip step may take.
-const TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(any(feature = "tungstenite", feature = "axum"))]
+const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// `from_tungstenite`: bytes round-trip both ways between the adapter and a raw
 /// tokio-tungstenite peer connected over an in-memory duplex (no sockets, no
 /// HTTP handshake — `from_raw_socket` just sets up framing per role).
+#[cfg(feature = "tungstenite")]
 #[tokio::test]
 async fn from_tungstenite_round_trips_binary_frames() {
+    use bytes::Bytes;
+    use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::protocol::Role;
     use tokio_tungstenite::tungstenite::Message;
     use tokio_tungstenite::WebSocketStream;
@@ -36,10 +33,13 @@ async fn from_tungstenite_round_trips_binary_frames() {
     let (mut sink, mut stream) = kble_socket::from_tungstenite(server);
 
     // peer -> adapter stream
-    client
-        .send(Message::Binary(b"to the adapter".to_vec()))
-        .await
-        .expect("peer sends a binary frame");
+    tokio::time::timeout(
+        TIMEOUT,
+        client.send(Message::Binary(b"to the adapter".to_vec())),
+    )
+    .await
+    .expect("peer send timed out")
+    .expect("peer sends a binary frame");
     let got = tokio::time::timeout(TIMEOUT, stream.next())
         .await
         .expect("adapter stream timed out")
@@ -48,8 +48,9 @@ async fn from_tungstenite_round_trips_binary_frames() {
     assert_eq!(&got[..], b"to the adapter");
 
     // adapter sink -> peer (a binary frame, per the adapter's encoding)
-    sink.send(Bytes::from_static(b"from the adapter"))
+    tokio::time::timeout(TIMEOUT, sink.send(Bytes::from_static(b"from the adapter")))
         .await
+        .expect("adapter sink send timed out")
         .expect("adapter sink accepts a frame");
     match tokio::time::timeout(TIMEOUT, client.next())
         .await
@@ -65,18 +66,21 @@ async fn from_tungstenite_round_trips_binary_frames() {
 /// `from_axum`: bytes round-trip through a real (in-process) axum server whose
 /// handler echoes via the adapter, driven by a real tokio-tungstenite client
 /// that performs the actual HTTP upgrade.
+#[cfg(feature = "axum")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn from_axum_round_trips_binary_frames() {
     use axum::extract::ws::WebSocketUpgrade;
     use axum::response::Response;
     use axum::routing::get;
     use axum::Router;
+    use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::Message;
 
     async fn echo(upgrade: WebSocketUpgrade) -> Response {
         upgrade.on_upgrade(|ws| async move {
             let (mut sink, mut stream) = kble_socket::from_axum(ws);
-            // Echo every frame back through the adapter's sink.
+            // Echo every frame back through the adapter's sink. A stall here
+            // surfaces as the client's bounded receive timing out below.
             while let Some(Ok(frame)) = stream.next().await {
                 if sink.send(frame).await.is_err() {
                     break;
@@ -104,9 +108,9 @@ async fn from_axum_round_trips_binary_frames() {
     .expect("connect timed out")
     .expect("websocket upgrade against the echo server");
 
-    client
-        .send(Message::Binary(b"echo me".to_vec()))
+    tokio::time::timeout(TIMEOUT, client.send(Message::Binary(b"echo me".to_vec())))
         .await
+        .expect("client send timed out")
         .expect("client sends a binary frame");
     match tokio::time::timeout(TIMEOUT, client.next())
         .await
@@ -118,6 +122,6 @@ async fn from_axum_round_trips_binary_frames() {
         other => panic!("expected a binary echo, got: {other:?}"),
     }
 
-    // Bounded like the rest of the awaits: a hung close shouldn't stall the suite.
+    // Bounded like the rest: a hung close shouldn't stall the suite.
     let _ = tokio::time::timeout(TIMEOUT, client.close(None)).await;
 }

--- a/kble-socket/tests/adapters.rs
+++ b/kble-socket/tests/adapters.rs
@@ -86,6 +86,10 @@ async fn from_axum_round_trips_binary_frames() {
     }
 
     let app = Router::new().route("/", get(echo));
+    // axum 0.6 server setup. At the axum 0.8 bump (#174) this migrates to
+    // `tokio::net::TcpListener::bind` + `axum::serve` — the same change the
+    // binary needs; the WebSocketUpgrade -> `from_axum` path under test is
+    // unchanged, so the adapter stays covered across the bump.
     let server = axum::Server::bind(&"127.0.0.1:0".parse().unwrap()).serve(app.into_make_service());
     let addr = server.local_addr();
     tokio::spawn(async move {
@@ -114,5 +118,6 @@ async fn from_axum_round_trips_binary_frames() {
         other => panic!("expected a binary echo, got: {other:?}"),
     }
 
-    client.close(None).await.ok();
+    // Bounded like the rest of the awaits: a hung close shouldn't stall the suite.
+    let _ = tokio::time::timeout(TIMEOUT, client.close(None)).await;
 }

--- a/kble-socket/tests/adapters.rs
+++ b/kble-socket/tests/adapters.rs
@@ -6,11 +6,20 @@
 //! surfacing as a confusing failure somewhere downstream.
 //!
 //! Enabled when both `tungstenite` and `axum` are on, as in a workspace build.
+//!
+//! Every receive/connect await is bounded by [`TIMEOUT`]: a regression that
+//! stops an adapter producing frames should fail fast at the offending line, not
+//! hang the test (and CI) indefinitely.
 
 #![cfg(all(feature = "tungstenite", feature = "axum"))]
 
+use std::time::Duration;
+
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
+
+/// Upper bound on how long any single round-trip step may take.
+const TIMEOUT: Duration = Duration::from_secs(5);
 
 /// `from_tungstenite`: bytes round-trip both ways between the adapter and a raw
 /// tokio-tungstenite peer connected over an in-memory duplex (no sockets, no
@@ -31,9 +40,9 @@ async fn from_tungstenite_round_trips_binary_frames() {
         .send(Message::Binary(b"to the adapter".to_vec()))
         .await
         .expect("peer sends a binary frame");
-    let got = stream
-        .next()
+    let got = tokio::time::timeout(TIMEOUT, stream.next())
         .await
+        .expect("adapter stream timed out")
         .expect("adapter stream yields a frame")
         .expect("frame is not an error");
     assert_eq!(&got[..], b"to the adapter");
@@ -42,9 +51,9 @@ async fn from_tungstenite_round_trips_binary_frames() {
     sink.send(Bytes::from_static(b"from the adapter"))
         .await
         .expect("adapter sink accepts a frame");
-    match client
-        .next()
+    match tokio::time::timeout(TIMEOUT, client.next())
         .await
+        .expect("peer receive timed out")
         .expect("peer receives a frame")
         .expect("frame is not an error")
     {
@@ -83,17 +92,21 @@ async fn from_axum_round_trips_binary_frames() {
         server.await.expect("axum server runs");
     });
 
-    let (mut client, _resp) = tokio_tungstenite::connect_async(format!("ws://{addr}/"))
-        .await
-        .expect("websocket upgrade against the echo server");
+    let (mut client, _resp) = tokio::time::timeout(
+        TIMEOUT,
+        tokio_tungstenite::connect_async(format!("ws://{addr}/")),
+    )
+    .await
+    .expect("connect timed out")
+    .expect("websocket upgrade against the echo server");
 
     client
         .send(Message::Binary(b"echo me".to_vec()))
         .await
         .expect("client sends a binary frame");
-    match client
-        .next()
+    match tokio::time::timeout(TIMEOUT, client.next())
         .await
+        .expect("echo receive timed out")
         .expect("client receives the echo")
         .expect("frame is not an error")
     {


### PR DESCRIPTION
Tracking issue: #196 (the second task — adapter-level guard for dependency bumps)

## What

Isolated round-trip tests for `kble_socket`'s two externally-facing adapters, which convert a transport's WebSocket into the binary `SocketSink` / `SocketStream` pair:

- **`from_tungstenite`** — over an in-memory `tokio::io::duplex`, against a raw `tokio-tungstenite` peer (`from_raw_socket`, no sockets / no HTTP handshake). Round-trips a binary frame both ways.
- **`from_axum`** — against a real, in-process axum server whose handler echoes via the adapter, driven by a real `tokio-tungstenite` client doing the actual HTTP upgrade.

## Why

These adapters were only exercised **end-to-end** (through plug processes, and `from_axum` via kble-serialport in #197). So an axum / tokio-tungstenite bump (#174) that broke an adapter would surface as a confusing *downstream* failure. These tests fail at the boundary instead, making dependency-bump triage easy: if the bump breaks the byte↔frame conversion, the failure points straight at `kble_socket`.

## Notes

- Gated on the `tungstenite` + `axum` features, which are both on in a workspace build — so they run under `cargo test` (verified: `Running tests/adapters.rs … ok`). A no-feature `cargo test -p kble-socket` simply skips them (0 tests).
- Test-only deps added to `kble-socket` dev-dependencies: `tokio-tungstenite` (the peer/client), `axum` with `tokio`/`http1`/`ws` (the in-process server), plus tokio test features. No change to the crate's real dependency surface.
- `from_axum`'s server binds `127.0.0.1:0` and reads back `local_addr()`, so there's no free-port race (flake-checked 20×, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)