### PR TITLE
ci: declare and verify MSRV (1.78)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,14 @@ jobs:
       - name: cache dependencies
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
+      # The binary crates' build scripts invoke cargo-about (via notalawyer-build)
+      # to bundle license info, so it must be on PATH even for a plain check. Use
+      # a prebuilt binary so we don't recompile it under the MSRV toolchain.
+      - name: install cargo-about
+        uses: taiki-e/install-action@cde8c9e634f4a17bc06b61413ac0ef75450eac46 # v2.81.4
+        with:
+          tool: cargo-about@${{ env.CARGO_ABOUT_VERSION }}
+
       # Verify the declared MSRV actually compiles. --all-targets pulls in the
       # dev-dependencies (notably proptest, which is version-capped in Cargo.toml
       # to keep this MSRV), and --locked ensures the committed Cargo.lock resolves

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,3 +63,29 @@ jobs:
 
       - name: unit test
         run: cargo test
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+
+      - name: Get MSRV
+        id: msrv
+        run: |
+          awk -F'[ ="]+' '$1 == "rust-version" { print "msrv=" $2 }' Cargo.toml >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv }}
+
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
+
+      # Verify the declared MSRV actually compiles. --all-targets pulls in the
+      # dev-dependencies (notably proptest, which is version-capped in Cargo.toml
+      # to keep this MSRV), and --locked ensures the committed Cargo.lock resolves
+      # to versions that build on the MSRV toolchain.
+      - name: check MSRV
+        run: cargo check --workspace --all-targets --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "Virtual Harness Toolkit"
 repository = "https://github.com/arkedge/kble"
 license = "MIT"
 edition = "2021"
+rust-version = "1.78"
 readme = "README.md"
 
 [workspace]

--- a/kble-c2a/Cargo.toml
+++ b/kble-c2a/Cargo.toml
@@ -3,6 +3,7 @@ name = "kble-c2a"
 description.workspace = true
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/kble-dump/Cargo.toml
+++ b/kble-dump/Cargo.toml
@@ -3,6 +3,7 @@ name = "kble-dump"
 description.workspace = true
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/kble-eb90/Cargo.toml
+++ b/kble-eb90/Cargo.toml
@@ -3,6 +3,7 @@ name = "kble-eb90"
 description.workspace = true
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/kble-serialport/Cargo.toml
+++ b/kble-serialport/Cargo.toml
@@ -3,6 +3,7 @@ name = "kble-serialport"
 description.workspace = true
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/kble-socket/Cargo.toml
+++ b/kble-socket/Cargo.toml
@@ -3,6 +3,7 @@ name = "kble-socket"
 description.workspace = true
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/kble-tcp/Cargo.toml
+++ b/kble-tcp/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 readme.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/kble-test-support/Cargo.toml
+++ b/kble-test-support/Cargo.toml
@@ -3,6 +3,7 @@ name = "kble-test-support"
 description = "Test-only helpers for driving kble plug processes over WebSocket-over-stdio"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish = false

--- a/kble/Cargo.toml
+++ b/kble/Cargo.toml
@@ -3,6 +3,7 @@ name = "kble"
 description.workspace = true
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true


### PR DESCRIPTION
## What

- Declare the MSRV explicitly: `rust-version = "1.78"` in `[workspace.package]`, inherited by all 8 member crates via `rust-version.workspace = true`.
- Add an `msrv` CI job that extracts the MSRV from `Cargo.toml` and verifies it builds.

## Why

This repo already had a de-facto MSRV of 1.78 — it matches the pinned [`rust-toolchain`](rust-toolchain), and `proptest` is version-capped (`>=1.5, <1.7`) in `Cargo.toml` *specifically* to avoid raising it. But that was never expressed as package metadata, so:

- `cargo` couldn't take the MSRV into account during dependency resolution.
- Consumers of the published crates (e.g. `kble-socket`) had no declared minimum.
- Nothing verified the declared/de-facto MSRV against what actually compiles.

## CI job

The new `msrv` job mirrors how `verify-crate` extracts the toolchain channel — it `awk`s the `rust-version` out of `Cargo.toml` (single source of truth) and runs:

```
cargo check --workspace --all-targets --locked
```

- `--all-targets` pulls in dev-dependencies (notably `proptest`), so the version cap that keeps the MSRV is actually exercised.
- `--locked` ensures the committed `Cargo.lock` resolves to versions that build on the MSRV toolchain.

Verified locally on `1.78.0` — `cargo check --workspace --all-targets --locked` completes cleanly. `actionlint` passes on the workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)