### PR TITLE
ci: run publish dry-run on stable, not the MSRV toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,18 +132,22 @@ jobs:
     name: publish (dry-run)
     runs-on: ubuntu-24.04
 
+    # This job checks that each crate is publishable to crates.io, which is a
+    # question about current stable Cargo, not our MSRV. Library crates don't
+    # ship their Cargo.lock, so the verify build re-resolves dependencies; on
+    # the MSRV-pinned toolchain that pulls in deps requiring a newer Cargo (e.g.
+    # idna_adapter needs the edition2024 feature, stabilized in 1.85). The MSRV
+    # is verified separately by the `msrv` job in rust.yml. Run on stable and
+    # override the repo's rust-toolchain pin via RUSTUP_TOOLCHAIN.
+    env:
+      RUSTUP_TOOLCHAIN: stable
+
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Get Rust toolchain
-        id: toolchain
-        working-directory: .
-        run: |
-          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> "$GITHUB_OUTPUT"
-
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+          toolchain: stable
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 


### PR DESCRIPTION
## What

Run the Release workflow's `publish (dry-run)` job on **stable** instead of the MSRV-pinned toolchain (`rust-toolchain` = 1.78).

```diff
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@...
-      - name: Get Rust toolchain ...        # (read channel from rust-toolchain)
       - uses: dtolnay/rust-toolchain@... # v1
         with:
-          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+          toolchain: stable
```

## Why

The `publish (dry-run)` job has been failing on `main`:

```
error: failed to verify package tarball
  failed to parse manifest at `.../idna_adapter-1.2.2/Cargo.toml`
  feature `edition2024` is required
  ... not stabilized in this version of Cargo (1.78.0 ...).
```

`cargo publish` verifies each crate by building it **standalone**. The key asymmetry:

| crate | Cargo.lock in package tarball? | verify build |
|---|---|---|
| `kble` (bin) | ✅ included | uses locked `idna 0.5.0` → builds on 1.78 |
| `kble-socket` (lib) | ❌ not included | **re-resolves** → `url 2.5.8` → `idna 1.x` → `idna_adapter` (edition2024) → needs Cargo ≥ 1.85 → fails on 1.78 |

Library crates don't ship their `Cargo.lock` (a lib's lockfile is meaningless to downstream), so their verify build re-resolves deps fresh. On the MSRV toolchain (1.78) that pulls in `idna_adapter`, which requires the `edition2024` feature (stabilized in 1.85). Adding `--locked` doesn't help the lib, because there's no bundled lock to lock against.

Publishability to crates.io is a question about **current stable Cargo**, not our MSRV. So run this job on stable (overriding the repo's `rust-toolchain` pin via `RUSTUP_TOOLCHAIN`).

The **MSRV (1.78) is unaffected** — it stays verified by the `msrv` job in `rust.yml`, which checks the committed `Cargo.lock` with `--locked` (i.e. the locked build, which is the project's MSRV guarantee).

## Verification

Reproduced on `cargo 1.78.0` (the pinned MSRV) and `cargo 1.96.0` (stable) locally:

- 1.78 + `--locked`: `kble` (bin) verifies ✅, `kble-socket` (lib) fails ❌ on `idna_adapter` / edition2024.
- **stable**: `kble-socket` (and the rest) verify ✅.

`cargo package --list` confirms `kble` bundles `Cargo.lock` while `kble-socket` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)