### PR TITLE
ci: run checks on merge_group for the merge queue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  merge_group:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## What

Add the `merge_group` trigger to the Rust workflow.

```diff
 on:
   push:
     branches: [ main ]
   pull_request:
+  merge_group:
```

## Why

Prerequisite for enabling **Require merge queue** on the `protect main` ruleset.

GitHub's merge queue validates a PR by building it on a temporary branch combining the latest `main` with the PR (and any queued ahead of it), emitting a `merge_group` event. The required checks must run on that event — otherwise they never report against the queue's ref and PRs get **stuck in the queue**.

`verify-crate` and `msrv` (the checks required by `protect main`) both live in this workflow, so adding `merge_group` here is all that's needed. `pull_request` is kept so PRs still get CI before entering the queue.

## Rollout

1. Merge this (lands `merge_group` support on `main`).
2. Add the `merge_queue` rule to the `protect main` ruleset.

Doing it in this order avoids enabling the queue before the workflow can report against `merge_group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)