### PR TITLE
chore: raise MSRV and toolchain to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Virtual Harness Toolkit"
 repository = "https://github.com/arkedge/kble"
 license = "MIT"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.85"
 readme = "README.md"
 
 [workspace]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.85.0"


### PR DESCRIPTION
## What

Raise the MSRV and the pinned dev/CI toolchain from 1.78 to 1.85, keeping them coupled:

| file | before | after |
|---|---|---|
| `Cargo.toml` `rust-version` | 1.78 | **1.85** |
| `rust-toolchain` `channel` | 1.78.0 | **1.85.0** |

The `msrv` job reads `rust-version` from `Cargo.toml` and the other jobs read `rust-toolchain`, so CI follows automatically.

## Why

**1.85 stabilized the 2024 edition** (released 2025-02-20), and parts of the ecosystem now ship manifests that require it — Cargo 1.78 cannot even *parse* them:

- `url >= 2.5.1` → `idna 1.x` → `idna_adapter` (edition2024) — blocks #121
- `rmp-serde 1.x` (edition2024 manifest) — blocks #222

Staying on 1.78 meant those dependency updates fail CI structurally (`feature edition2024 is required`), and the lockfile ages while Renovate keeps retrying. 1.85 is ~16 months old at this point, which is still a conservative floor.

## Verification

- `cargo check --workspace --all-targets --locked` passes locally under `cargo 1.85.0` (same invocation as the `msrv` job).
- The publish dry-run job is unaffected (runs on stable since #209).

## Follow-ups (separate PRs)

- Rebase/retry #121 (url) and #222 (rmp-serde) — both should turn green on 1.85.
- The proptest cap comment in `Cargo.toml` references constraints from the 1.78 era and can be revisited.
- #116 (toolchain → 1.96) remains open if we later want to decouple the dev toolchain from the MSRV floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)