### PR TITLE
ci: install cargo-about as a prebuilt binary everywhere

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      # Prebuilt binary (like the msrv job in rust.yml): the tool's own rustc
+      # requirement must not be coupled to the workspace's pinned toolchain.
       - name: install cargo-about
-        run: |
-          cargo install --locked cargo-about --version ${{ env.CARGO_ABOUT_VERSION }}
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
+        with:
+          tool: cargo-about@${{ env.CARGO_ABOUT_VERSION }}
 
       - name: Build
         run: |
@@ -107,9 +110,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      # Prebuilt binary (like the msrv job in rust.yml): the tool's own rustc
+      # requirement must not be coupled to the workspace's pinned toolchain.
       - name: install cargo-about
-        run: |
-          cargo install --locked cargo-about --version ${{ env.CARGO_ABOUT_VERSION }}
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
+        with:
+          tool: cargo-about@${{ env.CARGO_ABOUT_VERSION }}
 
       - name: Build
         run: |
@@ -151,9 +157,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      # Prebuilt binary (like the msrv job in rust.yml): the tool's own rustc
+      # requirement must not be coupled to the workspace's pinned toolchain.
       - name: install cargo-about
-        run: |
-          cargo install --locked cargo-about --version ${{ env.CARGO_ABOUT_VERSION }}
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
+        with:
+          tool: cargo-about@${{ env.CARGO_ABOUT_VERSION }}
 
       - name: cargo publish (dry-run)
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,9 +38,12 @@ jobs:
       - name: cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      # Prebuilt binary (like the msrv job): the tool's own rustc requirement
+      # must not be coupled to the workspace's pinned toolchain.
       - name: install cargo-about
-        run: |
-          cargo install --locked cargo-about --version ${{ env.CARGO_ABOUT_VERSION }}
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
+        with:
+          tool: cargo-about@${{ env.CARGO_ABOUT_VERSION }}
 
       - name: reviewdog / clippy
         uses: sksat/action-clippy@87e08e0c289f2654fe702b0aaf88c2f1027a3e57 # v1.1.1


### PR DESCRIPTION
## What

Replace the four `cargo install --locked cargo-about` steps (rust.yml `verify-crate`, release.yml `build` ×2 / `publish_dry_run`) with the prebuilt-binary install the `msrv` job already uses:

```yaml
      - name: install cargo-about
        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
        with:
          tool: cargo-about@${{ env.CARGO_ABOUT_VERSION }}
```

## Why

cargo-about is a CI tool (license bundling via notalawyer-build), but compiling it from source under the pinned toolchain couples **the tool's rustc requirement to the workspace MSRV**. That broke #127:

```
error: cannot install package `cargo-about 0.9.0`, it requires rustc 1.88.0 or newer,
while the currently active rustc version is 1.85.0
```

With prebuilt binaries the tool version is independent of the toolchain — #127 (cargo-about 0.6.4 → 0.9.0) becomes mergeable without holding the MSRV hostage. Installs also get faster (no compile; the msrv job comment already documents this rationale).

The `CARGO_ABOUT_VERSION` env (and its Renovate regex manager) keeps working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)