### PR TITLE
chore: raise MSRV and toolchain to 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Virtual Harness Toolkit"
 repository = "https://github.com/arkedge/kble"
 license = "MIT"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.86"
 readme = "README.md"
 
 [workspace]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"


### PR DESCRIPTION
## What

| file | before | after |
|---|---|---|
| `Cargo.toml` `rust-version` | 1.85 | **1.86** |
| `rust-toolchain` `channel` | 1.85.0 | **1.86.0** |

## Why

Follow-up to #223. The url 2.5.x update (#121) pulls `idna 1.x`, whose `icu_*` 2.2.0 stack declares `rust-version = 1.86`:

```
error: rustc 1.85.0 is not supported by the following packages:
  icu_collections@2.2.0 requires rustc 1.86
  ...
```

One minor short of the 1.85 floor set this morning. 1.86 (April 2025) is still a conservative floor. The cargo-about 0.9 requirement (rustc 1.88) is handled separately by decoupling the tool install from the toolchain (#226), so the MSRV does not need to chase CI tools.

## Verification

Locally under `cargo 1.86.0`: `cargo check --workspace --all-targets --locked` and `cargo fmt --all --check` both pass.

## Follow-up

- Rebase/retry #121 (url 2.5.8) once this lands — should turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)