### PR TITLE
docs(ci): correct the cargo-hack feature-powerset comment

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,8 +83,9 @@ jobs:
       - name: cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      # The plugs always enable kble-socket with `stdio` + `tungstenite`, so a
-      # workspace build never exercises a single feature on its own. Check every
+      # A workspace build unifies kble-socket's features across all its
+      # consumers (one plug enables `stdio`+`tungstenite`, another `axum`, ...),
+      # so no single-feature combination is ever built on its own. Check every
       # feature combination so a crate that advertises a feature can't ship one
       # that fails to compile by itself.
       - name: install cargo-hack


### PR DESCRIPTION
The comment above the `install cargo-hack` step claimed every plug enables `kble-socket` with `stdio` + `tungstenite`, but `kble-serialport` enables the `axum` feature instead. The real reason `--feature-powerset` is needed: a workspace build unifies `kble-socket`'s features across all consumers, so no single-feature combination is ever built on its own.

Comment-only change (surfaced while reviewing CLAUDE.md in #236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)