### PR TITLE
ci: parallelize verify-crate into independent jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,17 @@ permissions:
   pull-requests: write
 
 jobs:
-  verify-crate:
+  # The crate verification (clippy, fmt, feature-powerset check, unit test) used
+  # to run as a single serial job, so wall-clock was the *sum* of every step.
+  # Since #229 pulled cargo-about in as a library build-dependency (via
+  # notalawyer-build 0.3), that heavy dependency tree is recompiled under each
+  # profile (dev for clippy, check for the powerset, test for the unit tests),
+  # which made the serial job ~36min. The work below is split into independent
+  # jobs that run concurrently (wall-clock ~= the slowest one), fronted by the
+  # `verify-crate` gate job so the branch-protection required check keeps its
+  # name. See issue #235.
+
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -34,11 +44,16 @@ jobs:
       - name: cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      # reviewdog's github-pr-review reporter only works on pull_request events;
-      # on merge_group (and push to main) there is no PR to attach review
-      # comments to, and reviewdog breaks the clippy output pipe (SIGPIPE, exit
-      # 141) as soon as clippy emits anything. clippy is advisory here (warnings
-      # never fail the build), so just skip it outside of PRs.
+      # This job mixes an always-required check (fmt) with an advisory, PR-only
+      # one (clippy):
+      #   - clippy runs only on pull_request and is advisory (warnings never
+      #     fail the build). reviewdog's github-pr-review reporter only works on
+      #     pull_request events; on merge_group (and push to main) there is no PR
+      #     to attach review comments to, and reviewdog breaks the clippy output
+      #     pipe (SIGPIPE, exit 141) as soon as clippy emits anything, so we skip
+      #     it outside of PRs.
+      #   - fmt runs everywhere and is what actually makes this job a meaningful
+      #     gate on merge_group / push.
       - name: reviewdog / clippy
         if: github.event_name == 'pull_request'
         uses: sksat/action-clippy@87e08e0c289f2654fe702b0aaf88c2f1027a3e57 # v1.1.1
@@ -47,6 +62,26 @@ jobs:
 
       - name: format
         run: cargo fmt --all --check
+
+  feature-powerset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
+
+      - name: Get Rust toolchain
+        id: toolchain
+        working-directory: .
+        run: |
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # The plugs always enable kble-socket with `stdio` + `tungstenite`, so a
       # workspace build never exercises a single feature on its own. Check every
@@ -60,8 +95,54 @@ jobs:
       - name: check feature powerset
         run: cargo hack check --feature-powerset --no-dev-deps --workspace
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
+
+      - name: Get Rust toolchain
+        id: toolchain
+        working-directory: .
+        run: |
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: unit test
         run: cargo test
+
+  verify-crate:
+    # Aggregate gate over the parallel jobs above. Branch protection requires a
+    # check named `verify-crate`; keeping that name here means the split needs
+    # no ruleset change. It runs unconditionally (`always()`) and fails unless
+    # every dependency reported `success`, so a failed/cancelled/skipped job
+    # cannot leave the required check unreported and silently unblock the merge
+    # queue.
+    needs: [ lint, feature-powerset, test ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: gate on dependency results
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          POWERSET_RESULT: ${{ needs.feature-powerset.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          echo "lint=$LINT_RESULT feature-powerset=$POWERSET_RESULT test=$TEST_RESULT"
+          for result in "$LINT_RESULT" "$POWERSET_RESULT" "$TEST_RESULT" ; do
+            if [ "$result" != "success" ]; then
+              echo "::error::a required job did not succeed"
+              exit 1
+            fi
+          done
+          echo "all required jobs succeeded"
 
   msrv:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

`Rust` workflow の `verify-crate` ジョブを並列化し、wall-clock を **~36分 → 最も遅いジョブ ≒ ~13分**(約1/3)に短縮する。Closes #235

## 背景

`verify-crate` は clippy / fmt / `cargo hack check --feature-powerset` / `cargo test` を**単一ジョブ内で直列実行**していたため wall-clock = 合計。#229 で notalawyer-build 0.3 が cargo-about を**ライブラリ build 依存**として取り込んだことで、巨大な依存ツリーが dev/check/test の各 profile で繰り返しコンパイルされ、直列化のコストが増幅されていた。

## 変更内容

`verify-crate` を独立した並列ジョブに分割:

| ジョブ | 内容 | 実行条件 |
|---|---|---|
| `lint` | clippy(reviewdog, PRのみ・advisory) + `cargo fmt --all --check`(常時) | 全イベント |
| `feature-powerset` | `cargo hack check --feature-powerset --no-dev-deps --workspace` | 全イベント |
| `test` | `cargo test` | 全イベント |
| `verify-crate` | **集約ゲート**: 上記3つを `needs` し、全て `success` のときのみ成功 | `if: ${{ always() }}` |

- **カバレッジ不変**: 実行コマンドは同一。並列に走るだけ。
- **ruleset 変更不要**: ジョブ名 `verify-crate` を維持しているため、"protect main" の `required_status_checks`(`verify-crate` / `msrv`)はそのまま。
- ゲートは `if: ${{ always() }}` で必ず実行し、依存結果を `success` 完全一致で判定。失敗/cancelled/skipped が required check を「未報告」のまま merge queue を通してしまう事故を防ぐ。

## 検証

- ローカルで `actionlint`(`run:` への shellcheck 込み)pass。
- 開発は TDD で実施(ワークフローの構造的不変条件を検証するテストで RED→GREEN を確認。テスト自体はリポジトリの footprint を考慮しコミットには含めていない)。
- PR 上で本ワークフロー自体が回るので、3ジョブ並列 + ゲートの実挙動はこの PR の Checks で確認できる。

## 採用しなかった案

- `--feature-powerset` → `--each-feature`: features を持つのは kble-socket のみ(3つ=8組合せ)で、支配的コストは cargo-about の一度のコンパイル。並列化だけで目標達成でき、組合せカバレッジを保てるため見送り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)