### PR TITLE
ci: save rust-cache only on the default branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,14 @@ jobs:
 
       - name: cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Persist the cache only from pushes to main; PRs and merge_group runs
+          # restore from main's cache (via restore-keys) but don't each save
+          # their own. rust-cache keys include the job name, so splitting
+          # verify-crate into three jobs (#235) tripled the cache count; with
+          # Renovate's frequent Cargo.lock churn, saving on every ref would blow
+          # past the repo's ~10 GiB Actions cache budget and thrash.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # This job mixes an always-required check (fmt) with an advisory, PR-only
       # one (clippy):
@@ -82,6 +90,14 @@ jobs:
 
       - name: cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Persist the cache only from pushes to main; PRs and merge_group runs
+          # restore from main's cache (via restore-keys) but don't each save
+          # their own. rust-cache keys include the job name, so splitting
+          # verify-crate into three jobs (#235) tripled the cache count; with
+          # Renovate's frequent Cargo.lock churn, saving on every ref would blow
+          # past the repo's ~10 GiB Actions cache budget and thrash.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The plugs always enable kble-socket with `stdio` + `tungstenite`, so a
       # workspace build never exercises a single feature on its own. Check every
@@ -114,6 +130,14 @@ jobs:
 
       - name: cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Persist the cache only from pushes to main; PRs and merge_group runs
+          # restore from main's cache (via restore-keys) but don't each save
+          # their own. rust-cache keys include the job name, so splitting
+          # verify-crate into three jobs (#235) tripled the cache count; with
+          # Renovate's frequent Cargo.lock churn, saving on every ref would blow
+          # past the repo's ~10 GiB Actions cache budget and thrash.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: unit test
         run: cargo test
@@ -162,6 +186,14 @@ jobs:
 
       - name: cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Persist the cache only from pushes to main; PRs and merge_group runs
+          # restore from main's cache (via restore-keys) but don't each save
+          # their own. rust-cache keys include the job name, so splitting
+          # verify-crate into three jobs (#235) tripled the cache count; with
+          # Renovate's frequent Cargo.lock churn, saving on every ref would blow
+          # past the repo's ~10 GiB Actions cache budget and thrash.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Verify the declared MSRV actually compiles. --all-targets pulls in the
       # dev-dependencies (notably proptest, which is version-capped in Cargo.toml


### PR DESCRIPTION
## 概要

`Rust` workflow の各 `Swatinem/rust-cache` ステップに **`save-if: ${{ github.ref == 'refs/heads/main' }}`** を付与し、**キャッシュ保存を main への push 時のみ**に限定する。PR / merge_group では restore-keys による**復元のみ**行う。issue #235 の改善案3(rust-cache チューニング)。

> [!NOTE]
> **Stacked on #238**(base = `fix/235-parallelize-verify-crate`)。#238 マージ後に base は自動で `main` へ張り替わります。差分は save-if 追加分のみ。

## 背景(実データ)

#238 で `verify-crate` を `lint` / `feature-powerset` / `test` に分割した。rust-cache のキャッシュキーは **ジョブ名を含む**(`v0-rust-<job>-<os>-<env>-<lock>`)ため、1ジョブ=1キャッシュだったものが **3キャッシュに増加**する。

計測時点でリポジトリの Actions キャッシュは **9.56 GiB / 10 GiB(26 entries)とほぼ上限**。さらに Renovate が Cargo.lock を頻繁に更新するたびに新キーのキャッシュが生成されており(`verify-crate` キーが lock ハッシュ違いで複数存在)、分割でこの churn が **×3** に増える。デフォルト挙動(全 ref で保存)のままだと 10 GiB を超えて LRU eviction が多発し、せっかくの並列化の時短をキャッシュ thrash が相殺しかねない。

## 変更

`rust.yml` の4つの `rust-cache`(`lint` / `feature-powerset` / `test` / `msrv`)に `save-if: ${{ github.ref == 'refs/heads/main' }}` を追加:

- **PR / merge_group**: main のキャッシュから restore-keys で(部分)復元のみ。自前のキャッシュは保存しない → storage を消費せず churn ×3 を回避。
- **main push**: 正準キャッシュを保存 → 1系統に集約。
- per-job キーは**維持**(`shared-key` で共有しない。並列ジョブの同時保存レース + profile 差異で逆効果のため)。

## トレードオフ

- 依存変更後の **最初の main run は1回だけコールド**(以後の PR は温まったキャッシュを復元)。
- 同一 PR 内の複数 push 間でインクリメンタルなキャッシュ再利用はされない(各 push が main から復元)。本リポジトリでは影響軽微。

## 検証

- ローカルで `actionlint` pass。
- 4ステップ全てに save-if が付与されていることを確認(before 0 → after 4)。
- 効果(キャッシュ総量の頭打ち・PR の温キャッシュ復元)はマージ後の実運用で観測予定。

Refs #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)