### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0] - 2026-06-16
+
+### Added
+
+- `kble-c2a`: fragment oversized Space Packets across multiple AOS Transfer Frames ([#178](https://github.com/arkedge/kble/pull/178)).
+- `kble-socket`: read/write pipe stdio without dedicated blocking threads ([#189](https://github.com/arkedge/kble/pull/189)).
+- `kble-serialport`: best-effort macOS builds, alongside the existing Linux and Windows targets ([#239](https://github.com/arkedge/kble/pull/239)).
+
+### Changed
+
+- Raised the MSRV and pinned toolchain to Rust 1.88 ([#223](https://github.com/arkedge/kble/pull/223), [#229](https://github.com/arkedge/kble/pull/229)).
+- Updated `notalawyer` to 0.3, which invokes cargo-about as a library (no `cargo-about` binary needed at build time) ([#229](https://github.com/arkedge/kble/pull/229)).
+- Routine dependency, toolchain, and CI maintenance updates.
+
+### Fixed
+
+- `kble`: exit cleanly when the final link closes ([#184](https://github.com/arkedge/kble/pull/184)).
+- `kble`: decode the percent-encoded `exec` command before running it ([#187](https://github.com/arkedge/kble/pull/187)).
+- `kble-tcp`: exit when either side of the bridge closes ([#186](https://github.com/arkedge/kble/pull/186)).
+- `kble-dump`: exit after replay completes ([#188](https://github.com/arkedge/kble/pull/188)).
+- `kble-eb90`: default `--buffer-size` to the maximum frame size ([#182](https://github.com/arkedge/kble/pull/182)).
+- `kble-serialport`: keep the pty slave open so the macOS E2E tests pass ([#241](https://github.com/arkedge/kble/pull/241)).
+
+## [0.4.2] - 2025-02-28
+
+### Changed
+
+- Updated the Rust toolchain to 1.78.0 ([#148](https://github.com/arkedge/kble/pull/148)).
+- Moved `about.toml` into each crate directory ([#152](https://github.com/arkedge/kble/pull/152)).
+- Adopted manual SemVer management ("trust semver by ourselves") ([#147](https://github.com/arkedge/kble/pull/147)).
+- Routine dependency maintenance updates.
+
+## [0.4.1] - 2025-01-30
+
+### Fixed
+
+- Close all streams even when one stream closes normally ([#139](https://github.com/arkedge/kble/pull/139)).
+
+### Changed
+
+- Routine dependency maintenance updates.
+
+## [0.4.0] - 2024-11-19
+
+### Added
+
+- `kble-dump`: new plug for dumping traffic ([#102](https://github.com/arkedge/kble/pull/102)).
+- `kble-tcp`: new plug bridging a TCP socket, with clap-based argument handling ([#98](https://github.com/arkedge/kble/pull/98)).
+- aarch64 Linux (musl) release binaries ([#131](https://github.com/arkedge/kble/pull/131)).
+- `cargo publish --dry-run` job in the release workflow ([#132](https://github.com/arkedge/kble/pull/132)).
+- `kble`: config validation ([#74](https://github.com/arkedge/kble/pull/74)) and byte-forwarding trace logs ([#90](https://github.com/arkedge/kble/pull/90)).
+
+### Changed
+
+- `kble`: graceful WebSocket shutdown ([#78](https://github.com/arkedge/kble/pull/78)); wait for child processes and kill them after a configurable grace period ([#82](https://github.com/arkedge/kble/pull/82)).
+- Updated `notalawyer` to 0.2.0 ([#123](https://github.com/arkedge/kble/pull/123)).
+- Routine dependency, toolchain, and CI maintenance updates.
+
+## [0.3.0] - 2024-02-28
+
+### Added
+
+- Release automation workflow distributing prebuilt binaries (Linux musl, plus `kble-serialport` for Windows) ([#60](https://github.com/arkedge/kble/pull/60)).
+- License NOTICE embedded in each binary via `notalawyer` / cargo-about ([#59](https://github.com/arkedge/kble/pull/59)).
+
+### Changed
+
+- Aligned `tokio-tungstenite` with axum 0.6 (bumped to 0.21) ([#64](https://github.com/arkedge/kble/pull/64)).
+
+### Fixed
+
+- Fix packet type handling.
+
+## [0.3.0-beta.1] - 2024-02-28
+
+### Added
+
+- Initial release-automation workflow, published as a pre-release to exercise the binary distribution pipeline.
+
+## [0.2.0] - 2023-06-02
+
+### Added
+
+- `kble-eb90`: new plug.
+- `kble-c2a`: `spacepacket` ([#27](https://github.com/arkedge/kble/pull/27)) and `tfsync` ([#24](https://github.com/arkedge/kble/pull/24)) subcommands.
+
+### Changed
+
+- Restructured the repository into a Cargo workspace (resolver v2, shared `workspace.package` and dependencies).
+- Use the `bytes` crate for buffer handling ([#3](https://github.com/arkedge/kble/issues/3)).
+
+## [0.1.0] - 2023-04-27
+
+Initial public release of kble: the `kble` orchestrator and its core plugs.
+
+[Unreleased]: https://github.com/arkedge/kble/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/arkedge/kble/compare/v0.4.2...v0.5.0
+[0.4.2]: https://github.com/arkedge/kble/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/arkedge/kble/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/arkedge/kble/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/arkedge/kble/compare/v0.3.0-beta.1...v0.3.0
+[0.3.0-beta.1]: https://github.com/arkedge/kble/compare/v0.2.0...v0.3.0-beta.1
+[0.2.0]: https://github.com/arkedge/kble/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/arkedge/kble/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "kble"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "kble-c2a"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "kble-dump"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "kble-eb90"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "kble-serialport"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "kble-socket"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "kble-tcp"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "kble-test-support"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.2"
+version = "0.5.0"
 description = "Virtual Harness Toolkit"
 repository = "https://github.com/arkedge/kble"
 license = "MIT"
@@ -35,7 +35,7 @@ clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"]}
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-kble-socket = "0.4"
+kble-socket = "0.5"
 # Capped below 1.7: proptest 1.7+ pulls rand 0.9/getrandom 0.3, which raise the
 # MSRV above this workspace's pinned toolchain (see rust-toolchain). Default
 # features (fork/timeout) are dropped to avoid the tempfile -> wit-bindgen path,


### PR DESCRIPTION
Release **v0.5.0** (`0.4.2` → `0.5.0`, minor).

This PR bumps the workspace version and the internal `kble-socket` requirement (`"0.4"` → `"0.5"`), and introduces a curated `CHANGELOG.md` ([Keep a Changelog](https://keepachangelog.com) format, covering all versions back to 0.1.0).

## Highlights

### Added
- `kble-c2a`: fragment oversized Space Packets across multiple AOS Transfer Frames
- `kble-socket`: read/write pipe stdio without dedicated blocking threads
- `kble-serialport`: best-effort macOS builds (#239)

### Changed
- Raised MSRV / pinned toolchain to Rust 1.88
- Adopted `notalawyer` 0.3 for license-notice generation

### Fixed
- `kble` / `kble-tcp` / `kble-dump`: exit cleanly when a link/replay closes
- `kble`: decode the percent-encoded `exec` command before running it
- `kble-eb90`: default `--buffer-size` to the maximum frame size
- `kble-serialport`: keep the pty slave open so the macOS E2E tests pass (#241)

See `CHANGELOG.md` for the full list.

## Release steps after merge
1. Tag the merge commit `v0.5.0` and push it.
2. The Release workflow builds the binaries, runs the publish dry-run, and creates a **draft** GitHub Release with auto-generated notes.

> Note: the `CHANGELOG.md` 0.5.0 date is set to 2026-06-16 — adjust if the tag lands on a different day.
