### PR TITLE
feat(ci): build and ship glibc (gnu) binaries via cross

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
       - main
     paths:
       - .github/workflows/release.yml
+      # The release build now depends on this verifier, so exercise the build
+      # (and the verify step) when the script changes too — otherwise a broken
+      # verifier would only surface at tag-release time.
+      - scripts/verify-release-binary.sh
 
 jobs:
   build:
@@ -130,6 +134,73 @@ jobs:
           if-no-files-found: error
           path: ./bin/
 
+  build_gnu:
+    name: build / glibc (${{ matrix.target }})
+    # glibc (dynamically linked) counterparts to the musl binaries built by the
+    # `build` job, shipped alongside them. Built with `cross` rather than a bare
+    # `cargo build`: cross's *-unknown-linux-gnu images are Ubuntu 20.04 based
+    # (glibc 2.31), so the binaries stay runnable on older distros. Building
+    # natively on this ubuntu-24.04 runner would instead bake in its glibc 2.39
+    # symbols and silently produce binaries that won't start on anything older.
+    # Only these gnu targets go through cross; the musl build remains a native
+    # cargo build (with the apt-installed musl-tools / aarch64 linker).
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Get Rust toolchain
+        id: toolchain
+        working-directory: .
+        run: |
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+
+      - name: install cross
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        with:
+          tool: cross
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Build
+        run: |
+          cross build --target=${{ matrix.target }} --release --locked
+
+      - name: Rename binaries
+        run: |
+          mkdir bin
+          kble_bins=("kble" "kble-c2a" "kble-dump" "kble-eb90" "kble-serialport" "kble-tcp")
+          for b in "${kble_bins[@]}" ; do
+            cp "./target/${{ matrix.target }}/release/${b}" "./bin/${b}-${{ matrix.target }}"
+          done
+          ls -lh ./bin
+
+      # Guard against a non-portable build: assert every binary is a glibc
+      # dynamic executable that runs on a glibc-2.31 system (see the script). The
+      # x86_64 binaries also get a real `--help` smoke run; the aarch64 ones are
+      # checked structurally only (can't execute on the x86_64 runner).
+      - name: Verify binaries are portable glibc builds
+        run: |
+          for f in ./bin/* ; do
+            ./scripts/verify-release-binary.sh --libc gnu "$f"
+          done
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-executable-${{ matrix.target }}
+          if-no-files-found: error
+          path: ./bin/
+
   publish_dry_run:
     name: publish (dry-run)
     runs-on: ubuntu-24.04
@@ -167,7 +238,7 @@ jobs:
 
   release:
     name: Release
-    needs: [ build, build_kble_serialport, publish_dry_run ]
+    needs: [ build, build_gnu, build_kble_serialport, publish_dry_run ]
     permissions:
       contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,16 @@ jobs:
           done
           ls -lh ./bin
 
+      # Mirror the gnu job's guard for the static musl binaries: assert each is
+      # fully static (no dynamic loader). The x86_64 ones also get a `--help`
+      # smoke run; the aarch64 ones are checked structurally only (can't execute
+      # on the x86_64 runner). No glibc floor applies to a static binary.
+      - name: Verify binaries are static musl builds
+        run: |
+          for f in ./bin/* ; do
+            ./scripts/verify-release-binary.sh --libc musl "$f"
+          done
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-executable-${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Release: ship glibc (dynamically linked) Linux binaries for `x86_64` and `aarch64`, alongside the existing musl (static) ones. Built with `cross`, whose Ubuntu 20.04 based images keep the binaries runnable on systems with glibc 2.31 or newer; a `verify-release-binary.sh` check enforces that floor so a non-portable build fails the release.
+- Release: ship glibc (dynamically linked) Linux binaries for `x86_64` and `aarch64`, alongside the existing musl (static) ones. Built with `cross`, whose Ubuntu 20.04 based images keep the binaries runnable on systems with glibc 2.31 or newer; a `verify-release-binary.sh` check enforces that floor (and the musl binaries' static linkage) so a non-portable build fails the release ([#244](https://github.com/arkedge/kble/pull/244)).
 
 ## [0.5.0] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Release: ship glibc (dynamically linked) Linux binaries for `x86_64` and `aarch64`, alongside the existing musl (static) ones. Built with `cross`, whose Ubuntu 20.04 based images keep the binaries runnable on systems with glibc 2.31 or newer; a `verify-release-binary.sh` check enforces that floor so a non-portable build fails the release.
+
 ## [0.5.0] - 2026-06-16
 
 ### Added

--- a/scripts/verify-release-binary.sh
+++ b/scripts/verify-release-binary.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# verify-release-binary.sh — assert a release binary is what we claim it is.
+#
+# We ship two flavours of Linux binary (see .github/workflows/release.yml):
+#   - musl: fully static, runs on any Linux regardless of installed libc.
+#   - gnu : dynamically linked against glibc. Built with `cross`, whose images
+#           use an old glibc (Ubuntu 20.04 = glibc 2.31) so the binary stays
+#           runnable on older distros. A naive `cargo build` on a modern runner
+#           would instead bake in that runner's (much newer) glibc symbols and
+#           silently produce a binary that won't start on older systems.
+#
+# This script is the guard against that failure mode. It is run both locally
+# (TDD loop) and from CI after each build, over every produced binary.
+#
+# Usage:
+#   verify-release-binary.sh --libc <gnu|musl> [--glibc-floor X.Y] [--no-run] <binary>
+#
+# Checks performed:
+#   1. linkage  — gnu must be dynamically linked (has a program interpreter);
+#                 musl must be statically linked.
+#   2. run      — the binary executes `--help` and exits 0. Skipped when the
+#                 binary's architecture differs from the host's (e.g. an
+#                 aarch64 artifact verified on an x86_64 CI runner): we can
+#                 check its shape but not run it without an emulator.
+#   3. glibc floor (gnu only) — the highest GLIBC_x.y symbol version the binary
+#                 requires must not exceed the floor, i.e. the binary must run
+#                 on a system whose glibc is as old as the floor. This is the
+#                 portability guarantee that justifies building with `cross`.
+#
+set -euo pipefail
+
+# cross's *-unknown-linux-gnu images are Ubuntu 20.04 based → glibc 2.31.
+DEFAULT_GLIBC_FLOOR="2.31"
+
+# assert_glibc_floor MAX FLOOR — the portability policy for the gnu binaries.
+#
+# Given MAX (the highest GLIBC_x.y[.z] version a binary requires, e.g. "2.34")
+# and FLOOR (the oldest glibc we promise to run on, e.g. "2.31"), pass (return
+# 0) iff the binary can run on a glibc-FLOOR system, i.e. MAX <= FLOOR. A binary
+# that needs newer symbols than the floor is a hard failure: that is the whole
+# point of building the gnu flavour with `cross` rather than a bare `cargo
+# build`, so a regression here must fail the release, not merely warn.
+#
+# Dotted versions do not compare as plain numbers (2.9 < 2.31), so we lean on
+# `sort -V`: it orders them correctly, putting the lower of {MAX, FLOOR} first.
+# MAX is acceptable exactly when it is that lower value (or equal to FLOOR).
+assert_glibc_floor() {
+  local max="$1" floor="$2"
+  [[ "$(printf '%s\n%s\n' "$max" "$floor" | sort -V | head -1)" == "$max" ]]
+}
+
+libc=""
+glibc_floor="$DEFAULT_GLIBC_FLOOR"
+run_check=1
+bin=""
+
+die() { echo "error: $*" >&2; exit 2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --libc)        libc="${2:-}"; shift 2 ;;
+    --glibc-floor) glibc_floor="${2:-}"; shift 2 ;;
+    --no-run)      run_check=0; shift ;;
+    -h|--help)     sed -n '2,33p' "$0"; exit 0 ;;
+    -*)            die "unknown flag: $1" ;;
+    *)             bin="$1"; shift ;;
+  esac
+done
+
+[[ -n "$libc" ]] || die "--libc <gnu|musl> is required"
+[[ "$libc" == "gnu" || "$libc" == "musl" ]] || die "--libc must be 'gnu' or 'musl', got '$libc'"
+[[ -n "$bin" ]] || die "no binary given"
+[[ -f "$bin" ]] || die "no such file: $bin"
+
+# --- architecture detection --------------------------------------------------
+# Map the ELF machine and `uname -m` onto a common arch token so we can tell
+# whether the binary can be executed on this host.
+elf_machine="$(readelf -h "$bin" | awk -F: '/Machine:/ { gsub(/^[ \t]+/, "", $2); print $2 }')"
+case "$elf_machine" in
+  *X86-64*)  bin_arch="x86_64" ;;
+  *AArch64*) bin_arch="aarch64" ;;
+  *)         bin_arch="unknown" ;;
+esac
+case "$(uname -m)" in
+  x86_64)          host_arch="x86_64" ;;
+  aarch64|arm64)   host_arch="aarch64" ;;
+  *)               host_arch="unknown" ;;
+esac
+
+fail=0
+note() { printf '  %s %s\n' "$1" "$2"; }
+pass() { note "PASS" "$1"; }
+bad()  { note "FAIL" "$1"; fail=1; }
+
+echo "verifying $bin (--libc $libc, arch $bin_arch)"
+
+# --- check 1: linkage --------------------------------------------------------
+file_out="$(file "$bin")"
+if [[ "$libc" == "musl" ]]; then
+  if [[ "$file_out" == *"statically linked"* ]]; then
+    pass "statically linked (musl)"
+  else
+    bad "expected a statically linked binary, got: $file_out"
+  fi
+else # gnu
+  if [[ "$file_out" == *"dynamically linked"* && "$file_out" == *"interpreter"* ]]; then
+    pass "dynamically linked against glibc"
+  else
+    bad "expected a dynamically linked glibc binary, got: $file_out"
+  fi
+fi
+
+# --- check 2: runs -----------------------------------------------------------
+if [[ "$run_check" -eq 0 ]]; then
+  note "SKIP" "run check disabled (--no-run)"
+elif [[ "$bin_arch" != "$host_arch" || "$bin_arch" == "unknown" ]]; then
+  note "SKIP" "run check: binary is $bin_arch, host is $host_arch (cannot execute natively)"
+else
+  if "$bin" --help >/dev/null 2>&1; then
+    pass "executes (--help exits 0)"
+  else
+    bad "binary did not run cleanly (--help exit $?)"
+  fi
+fi
+
+# --- check 3: glibc floor (gnu only) ----------------------------------------
+# Highest GLIBC_x.y[.z] version referenced in the binary's version-needs table.
+# `sort -V` understands dotted version order; tail -1 takes the maximum.
+max_glibc="$(readelf -V "$bin" 2>/dev/null \
+  | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' \
+  | sed 's/GLIBC_//' \
+  | sort -uV | tail -1 || true)"
+
+if [[ "$libc" == "gnu" ]]; then
+  if [[ -z "$max_glibc" ]]; then
+    bad "could not read any GLIBC symbol versions from $bin"
+  elif assert_glibc_floor "$max_glibc" "$glibc_floor"; then
+    pass "max required glibc ($max_glibc) is within floor ($glibc_floor)"
+  else
+    bad "binary requires glibc $max_glibc but the floor is $glibc_floor (not portable to older systems)"
+  fi
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "VERIFY FAILED: $bin"
+  exit 1
+fi
+echo "VERIFY OK: $bin"

--- a/scripts/verify-release-binary.sh
+++ b/scripts/verify-release-binary.sh
@@ -98,10 +98,14 @@ echo "verifying $bin (--libc $libc, arch $bin_arch)"
 # --- check 1: linkage --------------------------------------------------------
 file_out="$(file "$bin")"
 if [[ "$libc" == "musl" ]]; then
-  if [[ "$file_out" == *"statically linked"* ]]; then
-    pass "statically linked (musl)"
+  # A musl release binary is fully static: it carries no dynamic loader. `file`
+  # may report that as "statically linked" or, for the static-PIE that modern
+  # rustc emits, "static-pie linked" — so the invariant we assert is simply the
+  # absence of a program interpreter / dynamic linkage, not a fixed wording.
+  if [[ "$file_out" == *"dynamically linked"* || "$file_out" == *"interpreter"* ]]; then
+    bad "expected a static musl binary, got: $file_out"
   else
-    bad "expected a statically linked binary, got: $file_out"
+    pass "statically linked (musl)"
   fi
 else # gnu
   if [[ "$file_out" == *"dynamically linked"* && "$file_out" == *"interpreter"* ]]; then


### PR DESCRIPTION
## What

Distribute dynamically linked **glibc** binaries for `x86_64` and `aarch64` **alongside** the existing musl (static) ones. The musl build is unchanged.

## Why / how

A new `build_gnu` job builds the gnu targets with [`cross`](https://github.com/cross-rs/cross) rather than a bare `cargo build`. cross's `*-unknown-linux-gnu` images are Ubuntu 20.04 based (**glibc 2.31**), so the binaries stay runnable on older distros. Building natively on the `ubuntu-24.04` runner would instead bake in its glibc 2.39 symbols and silently produce binaries that won't start on anything older.

Only the gnu targets go through cross; the musl build stays a native `cargo build` with the apt-installed `musl-tools` / aarch64 linker.

`kble-serialport` builds cleanly under cross because `serialport 4.9` uses `nix` (sysfs) on Linux, not libudev — no extra C libs needed in the image.

## TDD / guard

`scripts/verify-release-binary.sh` is the test that captures the intended behavior, run from the `build_gnu` job over every produced binary:

1. **linkage** — gnu must be dynamically linked against glibc.
2. **run** — smoke-runs `--help` on the host-arch (x86_64) binaries; structurally checks the aarch64 ones (can't execute on an x86_64 runner).
3. **glibc floor** — the highest required `GLIBC_x.y` symbol version must be ≤ 2.31, so a non-portable build **fails the release** instead of shipping.

The floor discriminates exactly between a cross build (≤2.31, passes) and a native modern build (~2.39, fails). It's tunable via `--glibc-floor` / the script's `DEFAULT_GLIBC_FLOOR` if a target needs a different floor.

## Validation

The actual `cross` build can only be exercised in CI (no local container engine). This PR touches `.github/workflows/release.yml`, which is in the workflow's `pull_request` path filter, so opening it runs `build_gnu` end-to-end (build → verify) on Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)